### PR TITLE
Add script for custom PDF CV generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This repository contains a Hugo site for generating a curriculum vitae. A helper
 
 ```bash
 ./scripts/generate_cv.sh path/to/your.toml [output.pdf] [--standalone]
+
+The `--standalone` flag can be placed anywhere after the custom config path.
 ```
 
 The script merges `config.toml` with your custom file by default, builds the site with Hugo, and converts the generated HTML to PDF using a headless Chromium instance via Puppeteer.

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ This repository contains a Hugo site for generating a curriculum vitae. A helper
 ## Usage
 
 1. Create a TOML file with the values you want to override. See `config.sample.custom.toml` for a minimal example.
-2. Run the script:
+2. Ensure you have Node.js and npm installed.
+3. Run the script:
 
 ```bash
 ./scripts/generate_cv.sh path/to/your.toml [output.pdf]
 ```
 
-The script merges `config.toml` with your custom file, builds the site with Hugo, and converts the generated HTML to PDF using `wkhtmltopdf`.
+The script merges `config.toml` with your custom file, builds the site with Hugo, and converts the generated HTML to PDF using a headless Chromium instance via Puppeteer. Node dependencies are installed automatically on first run.
 
 The original configuration remains untouched.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ This repository contains a Hugo site for generating a curriculum vitae. A helper
 ./scripts/generate_cv.sh path/to/your.toml [output.pdf]
 ```
 
-The script merges `config.toml` with your custom file, builds the site with Hugo, and converts the generated HTML to PDF using a headless Chromium instance via Puppeteer. Node dependencies are installed automatically on first run.
+The script merges `config.toml` with your custom file, builds the site with Hugo, and converts the generated HTML to PDF using a headless Chromium instance via Puppeteer. The page in your configured default language is exported. Node dependencies are installed automatically on first run.
 
 The original configuration remains untouched.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# CV Generation
+
+This repository contains a Hugo site for generating a curriculum vitae. A helper script `scripts/generate_cv.sh` can build the site using an additional TOML configuration file and export it to PDF.
+
+## Usage
+
+1. Create a TOML file with the values you want to override. See `config.sample.custom.toml` for a minimal example.
+2. Run the script:
+
+```bash
+./scripts/generate_cv.sh path/to/your.toml [output.pdf]
+```
+
+The script merges `config.toml` with your custom file, builds the site with Hugo, and converts the generated HTML to PDF using `wkhtmltopdf`.
+
+The original configuration remains untouched.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This repository contains a Hugo site for generating a curriculum vitae. A helper
 ./scripts/generate_cv.sh path/to/your.toml [output.pdf] [--standalone]
 ```
 
-The script merges `config.toml` with your custom file by default, builds the site with Hugo, and converts the generated HTML to PDF using a headless Chromium instance via Puppeteer. Pass `--standalone` to use only your file and ignore the base configuration.
+The script merges `config.toml` with your custom file by default, builds the site with Hugo, and converts the generated HTML to PDF using a headless Chromium instance via Puppeteer.
+
+If you pass `--standalone`, only the supplied file is used. In that mode your configuration must define all required Hugo settings such as the theme. Otherwise Hugo will generate a nearly empty site and the PDF will contain just a directory listing.
 
 Node dependencies are installed automatically on first run.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ This repository contains a Hugo site for generating a curriculum vitae. A helper
 
 ## Usage
 
-1. Create a TOML file with the values you want to override. See `config.sample.custom.toml` for a minimal example.
+1. Create a TOML file with the values you want to override. See `config.sample.custom.toml` for a minimal example of disabling sections and changing text.
 2. Ensure you have Node.js and npm installed.
 3. Run the script:
 
 ```bash
-./scripts/generate_cv.sh path/to/your.toml [output.pdf]
+./scripts/generate_cv.sh path/to/your.toml [output.pdf] [--standalone]
 ```
 
-The script merges `config.toml` with your custom file, builds the site with Hugo, and converts the generated HTML to PDF using a headless Chromium instance via Puppeteer. The page in your configured default language is exported. Node dependencies are installed automatically on first run.
+The script merges `config.toml` with your custom file by default, builds the site with Hugo, and converts the generated HTML to PDF using a headless Chromium instance via Puppeteer. Pass `--standalone` to use only your file and ignore the base configuration.
 
-The original configuration remains untouched.
+Node dependencies are installed automatically on first run.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains a Hugo site for generating a curriculum vitae. A helper
 
 ```bash
 ./scripts/generate_cv.sh path/to/your.toml [output.pdf] [--standalone]
+./scripts/generate_cv.sh config.cv.toml sample.pdf --standalone
 
 The `--standalone` flag can be placed anywhere after the custom config path.
 ```

--- a/config.backup.toml
+++ b/config.backup.toml
@@ -1,0 +1,1015 @@
+# Page settings
+
+baseurl = "https://mboiman.github.io/"
+languageCode = "de-de"
+title = "Michael Boiman CV"
+theme = "my-hugo-orbit-theme"
+#googleAnalytics = "UA-XXXXXXX-Y"
+
+# Do not build files for websites. Need them? Set to false
+disableRSS = true
+disableSitemap = true
+disable404 = true
+
+
+
+# Mehrsprachige Konfiguration
+defaultContentLanguage = "de"
+defaultContentLanguageInSubdir = true
+
+[languages]
+  [languages.de]
+    languageCode = "de-de"
+    languageName = "Deutsch"
+    title = "Michael Boiman CV"
+    contentDir = "content/de"
+    weight = 1
+
+    [languages.de.params]
+      description = "Lebenslauf von Michael Boiman"
+      author = "Michael Boiman"
+      styles = "styles-6.css"
+
+      [languages.de.params.profile]
+        name = "Michael Boiman"
+        tagline = "Full-Stack Dev & Quality Engineer – KI-Automatisierungsexperte"
+        avatar = "profile.png"
+
+      [languages.de.params.contact]
+        enable = true
+
+        [[languages.de.params.contact.list]]
+        class = "email"
+        icon = "fa-envelope"
+        url = "mailto:mboiman@gmail.com"
+        title = "mboiman@gmail.com"
+
+        [[languages.de.params.contact.list]]
+        class = "phone"
+        icon = "fa-phone"
+        url = ""
+        title = "Auf Anfrage per E-Mail verfügbar"
+
+        [[languages.de.params.contact.list]]
+        class = "website"
+        icon = "fa-globe"
+        url = "http://boiman-kupermann.com"
+        title = "BKS-Lab"
+
+        [[languages.de.params.contact.list]]
+        class = "linkedin"
+        icon = "fa-linkedin"
+        url = "//linkedin.com/in/michael-boiman-ab709912"
+        title = "michael-boiman"
+
+        [[languages.de.params.contact.list]]
+        class = "github"
+        icon = "fa-github"
+        url = "//github.com/bks-lab"
+        title = "GitHub Profil"
+
+        [[languages.de.params.contact.list]]
+        class = "twitter"
+        icon = "fa-twitter"
+        url = "//twitter.com/mboiman"
+        title = "@mboiman"
+
+      [languages.de.params.education]
+        enable = true
+        title = "Ausbildung"
+
+        [[languages.de.params.education.list]]
+        degree = "Diplom-Informatiker (FH)"
+        college = "Fachhochschule Köln, Gummersbach"
+        dates = "2000 – 2005"
+
+        [[languages.de.params.education.list]]
+        degree = "ISTQB Certified Tester"
+        dates = "2005"
+
+      [languages.de.params.language]
+        enable = true
+        title = "Sprachen"
+
+        [[languages.de.params.language.list]]
+        language = "Deutsch"
+        level = "Muttersprache"
+
+        [[languages.de.params.language.list]]
+        language = "Englisch"
+        level = "Fließend"
+
+        [[languages.de.params.language.list]]
+        language = "Russisch"
+        level = "Konversationslevel"
+
+        [[languages.de.params.language.list]]
+        language = "Hebräisch"
+        level = "Konversationslevel"
+
+      [languages.de.params.interests]
+        enable = false
+        title  = "Interessen"
+
+        [[languages.de.params.interests.list]]
+        interest = "Gaming"
+
+        [[languages.de.params.interests.list]]
+        interest = "Basketball"
+
+      [languages.de.params.summary]
+        enable = true
+        icon = "fa-user"
+        title = "Karriereprofil"
+        summary = """\
+Mit mehr als 20 Jahren Erfahrung in der Softwareentwicklung liegt mein Fokus auf der Automatisierung von Geschäfts- und Qualitätsprozessen sowie der Integration künstlicher Intelligenz. Zu meinen fachlichen Schwerpunkten zählen:
+- **KI-Automatisierung**: Optimierung und Implementierung von KI in bestehende Geschäftsprozesse.
+- **Python-Expertise**: Umfassende Erfahrung in der Entwicklung von KI-basierten Lösungen, Automatisierungen und Datenanalysen mit Python.
+- **Geschäftsprozess-Automatisierung**: Effizienzsteigerung durch Automatisierung manueller Abläufe und Datenverarbeitung.
+- **Entwicklung eines KI-Mail-Bots**: Automatisierte E-Mail-Verarbeitung und Datenabgleich mit Drittsystemen.
+- **Erfahrung mit LLMs**: Einsatz von GPT, Claude, Gemini, Llama, Mistral, RAGs, Agentic AI, MCP, A2A u.a.
+- **Testautomatisierung**: Einrichtung von Quality-Gates innerhalb der CI/CD-Pipeline.
+- **Echtzeit-Monitoring**: Entwicklung von Systemen zur Darstellung des Qualitätsstands in Echtzeit.
+- **ML und DL-Modelle**: Integration von Machine Learning und Deep Learning in Geschäftsprozesse.
+- **Performance-Tests**: Durchführung von Last- und Performance-Tests.
+- **Entwicklung**: Expertise in Java, JavaScript, Swift, Python und weiteren Sprachen.
+- **DevOps**: Erfahrung mit GitHub, GitLab, Jenkins und anderen CI/CD-Tools.
+- **Contract-Testing**: Anwendung von Pact.io oder Spring Contract.
+- **Cloud-Technologien**: Kenntnisse in Kubernetes, Helm, Terraform, ArgoCD u.a.
+- **Mobile Entwicklung**: Fundierte Erfahrungen in der Entwicklung mobiler Anwendungen mit Swift und Flutter.
+- **Agile Methoden**: Praktische Anwendung von Scrum und SAFE.
+- **Teamleitung**: Leitung und Koordination von interdisziplinären Teams.
+        """
+
+      [languages.de.params.experiences]
+        enable = true
+        icon = "fa-briefcase"
+        title = "Berufserfahrung"
+
+        [[languages.de.params.jobs.list]]
+        position = "Quality Lead"
+        dates = "08/2021 – 05/2025"
+        company = "DVAG"
+        details = """
+**Testmanagement & Testkoordination**, sowie Einführung von CICD mit Aufbau von QualityGates** Koordination als Quality-Lead (übergreifendes QA-Team) inklusive Einarbeitung, Hilfestellung, Beratung, Schulung zur Einführung von Qualitätsmetriken und Testautomatisierung innerhalb der Pipeline, Teamübergreifend 
+**Schwerpunkte** 
+- Konzeption und Aufbau vom fachlichen und technischen Dashboards mit Grafana zur Echtzeitmessung der Qualität 
+- Dokumentation von Qualitätsmetriken über Fortschritt der messbaren Qualität der Sprints 
+- Aufbau und Konzeption einer CICD-Pipeline für verschiedene Entwicklungs-Teams (Backend + Frontend) 
+- Einführung von QualityGates zur Sicherung der Qualität innerhalb der CICD-Pipeline
+- Einführung von Gauge (BDD) 
+- Einführung von Playwright und Integration in bestehende CICD-Pipeline
+- Fachliche und technische Analyse von Incidents 
+- Beratung sowie Konzeption und Umsetzung von Lösungen für qualitäts-relevante Probleme 
+
+**Tools** 
+- IntelliJ / Visual Studio Code 
+- Java / Java-Script / Typescript 
+- Playwright / Gauge / Taiko / Karate 
+- Python für die Aufbereitung und Analyse von Test- und Reportdaten
+- CI/CD / Github – reuseable workflows 
+- Helm / Container 
+- JIRA / Confluence 
+- Grafana 
+- Behavioral-Driven Development 
+- Consumer Driven Contracts (Pact.io) 
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Technische Leitung & Entwicklung"
+        dates    = "01/2024 – 04/2025"
+        company  = "BKS"
+        details  = """
+**Technische Leitung & Entwicklung**: Konzeption und Umsetzung einer skalierbaren Automatisierungslösung für die Verarbeitung von E-Rechnungen und PDF-Rechnungen aus dem Postfach einer führenden Online-Jobplattform. Vollständige Verantwortung von der Anforderungsanalyse über die Implementierung bis zur Produktionseinführung.
+
+**Schwerpunkte**:
+- **Workflow-Automatisierung**: Extraktion, Analyse und Klassifizierung eingehender Rechnungen mittels Python und Azure Functions.
+- **E-Rechnungs-Klassifizierung & Daten-Extraction**: Vollständige Verarbeitung nach EU-Standards (EN 16931: ZUGFeRD, XRechnung), inklusive Struktur- und Inhalts-Parsing.
+- **Salesforce-Einspielung**: Weiterleitung der aufbereiteten Rechnungsdaten per E-Mail an das nachgelagerte System für den Salesforce-Import.
+- **Auditierung & Protokollierung**: Lückenlose Dokumentation aller Verarbeitungsschritte sowie Speicherung der ursprünglichen E-Mail-Inhalte im Verarbeitungsprotokoll.
+- **Outlook-Management & SharePoint-Archivierung**: Automatisches Verschieben und Kategorisieren von E-Mails in vordefinierte Zielordner in Outlook; Archivierung von Original- und generierten Rechnungsdokumenten über Microsoft Graph API.
+- **Monitoring & Logging**: Echtzeit-Überwachung des End-to-End-Prozesses mit Kibana, inklusive Alerting und Dashboard-Erstellung.
+- **Team-Koordination**: Steuerung des Entwickler-Teams inkl. Code-Reviews.
+
+**Tools & Technologien**
+- Azure Functions: Serverlose Orchestrierung der Automatisierungs-Workflows.
+- Python: Implementierung der Kernlogik für Datenextraktion, Klassifizierung und Integration mit automatisierten CI/CD-Prozessen, Paketierung und umfassenden Unit- sowie Integrationstests zur Qualitätssicherung.
+- Microsoft Graph API: Zugriff auf Outlook-Postfächer und SharePoint-Dokumentbibliotheken.
+- GitHub: Versionskontrolle, CI/CD-Pipelines und kollaborative Entwicklung.
+- Kibana: Monitoring, Log-Analyse und Performance-Dashboards.
+- Streamlit: Für die Entwicklung einer interaktiven Webanwendung zur Visualisierung.
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Technische Leitung & Entwicklung"
+        dates = "04/2023 - 04/2024"
+        company = "Ryze"
+        details = """
+**Projektmanagement & Technische Leitung**: Entwicklung und Einführung eines KI-gesteuerten E-Mail-Bots zur Automatisierung der Kundenkommunikation, KI-gestützte Verarbeitung eingehender E-Mails und Auslösen von Folge-Aktivitäten in bestehenden SAP-Systeme. Verantwortlich für die End-to-End-Projektkoordination und Teamsteuerung von der Idee bis zur Implementierung.
+
+**Schwerpunkte**:
+- **Entwicklung von ML-Modellen**: Entwurf und Training spezialisierter Modelle zur effektiven Klassifizierung von E-Mails, realisiert durch Azure Functions.
+- **API-Integrationen**: Nahtlose Anbindung an Microsoft Outlook 365 über die Microsoft Graph API und an SAP-Systeme zur Überprüfung von Kundendaten.
+- **Prozessautomatisierung**: Automatisches Verschieben von E-Mails basierend auf Klassifikation und spezifischen Geschäftsregeln, inklusive der Bearbeitung von Reklamationen.
+- **DevOps und Monitoring**: Implementierung von CI/CD Pipelines sowie Einsatz von Kibana für das Monitoring.
+- **Entwicklung einer Streamlit-basierten Benutzeroberfläche**: Verbesserung der Testbarkeit und Visualisierung von Prozessergebnissen.
+- **Team-Betreuung**: Technische Anleitung der Entwickler mit regelmäßigen Code-Reviews und Problemlösungssessions.
+
+**Tools & Technologien**
+- Azure Functions: Für serverlose Anwendungsarchitekturen und die Ausführung von ML-Modellen.
+- Python: Hauptprogrammiersprache für die Entwicklung des E-Mail-Bots und der ML-Modelle.
+- Microsoft Graph API: Für den Zugriff und die Verarbeitung von E-Mails im Microsoft Outlook 365.
+- SAP API: Für die Abfrage von Kundendaten und die Kommunikation mit SAP-Systemen.
+- GitHub: Für Versionskontrolle, CI/CD Pipelines und den kollaborativen Entwicklungsprozess.
+- Kibana: Für das Echtzeit-Monitoring und die Analyse der Systemleistung.
+- Streamlit: Für die Entwicklung einer interaktiven Webanwendung zur Systemüberwachung.
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Anwendungen von KI im Geschäftsumfeld"
+        dates = "2023"
+        company = "KI-Workshop zur Unternehmenseinbindung"
+        details = """
+**KI-Workshop** Umfassende Präsentation und Live-Demonstration innovativer KI-Anwendungen für die Geschäftswelt mit Fokus auf praktische Umsetzung, Theorie und Code-Beispiele
+
+**Präsentationsinhalte**
+- Umfassender Überblick über KI-Bereiche und -Patterns (Supervised/Unsupervised/Semi-Supervised Learning)
+- Vertiefte Einblicke in Machine Learning, Deep Learning und Natural Language Processing
+- Detaillierte Betrachtung von GPT-Modellen und deren Funktionsweise (Next Token Prediction)
+- Praktisches Prompt Engineering mit Beispielen für verschiedene Anwendungsfälle
+- Vorstellung von Tools wie Hugging Face, Stable Diffusion, Midjourney und Auto-GPT
+
+**Praktischer Workshop-Teil**
+- Entwicklung eines intelligenten Q&A-Bots mit OpenAI GPT-3.5-Turbo
+- Live-Entwicklung eines Webscrapers zur Datenakquise
+- Extraktion und Vektorisierung von Text-Embeddings mit OpenAI-Modellen
+- Implementierung von Similarity Search für kontextbezogene Antworten
+- Ähnlichkeitsanalyse und Visualisierung der Ergebnisse
+- Erstellung einer interaktiven Streamlit-Benutzeroberfläche für den Q&A-Bot
+
+**Eingesetzte Technologien**
+- OpenAI API (GPT-3.5-Turbo, Embedding-Ada-002)
+- Python mit Pandas, NumPy und Streamlit
+- Vector Embeddings und Cosine-Similarity für semantische Suche
+- Web-Scraping mit BeautifulSoup und Requests
+- Prompt Engineering und KI-Integration in Geschäftsprozesse
+- Integration über RESTful APIs
+
+Die vollständige Präsentation ist unter [Pitch.com](https://pitch.com/public/bc7eaebb-5fb1-4e6f-bf84-ce9363c7abc0) verfügbar. Der komplette Quellcode des entwickelten Q&A-Bots ist in meinem [GitHub-Repository](https://github.com/boiman-solutions/workshop-q-a-scrap-bot) dokumentiert.
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Quality-Lead"
+        dates = "01/2017 - 05/2021"
+        company = "DB Vertrieb"
+        details = """
+**Testmanagement, Testkoordination, Testautomatisierung - Agil (Kanban, Scrum, SAFE)** Koordination als PO eines übergreifendes QA-Teams inklusive teamübergreifender Einarbeitung, Hilfestellung, Beratung, Schulung 
+**Schwerpunkte** 
+- Agile Qualitätssicherung durch Konzeption von QualityGates in der CI/CD Pipeline 
+- Konzeption und Aufbau vom fachlichen und technischen Dashboards mit Kibana, Graylog, Grafana, Instana & Elastic Search 
+- Performance Tests innerhalb der CI/CD mit Gatling / JMeter und Analyse mittels Kibana, Graylog, Grafana und Instana 
+- Dokumentation von Qualitätsmetriken über Fortschritt der messbaren Qualität der Sprints 
+- Aufbau und Konzeption von CI/CD-Pipeline für Daten-Tests 
+- Fachliche und technische Analyse von Problemen 
+- Beratung sowie Konzeption und Umsetzung von Lösungen für qualitäts-relevante Probleme 
+- Aufbau von Junit, Unit-Tests und Integrationstests unter anderen mit Java Cucumber 
+- Entwicklung einer hybriden App zur Präsentation (Review) der Ergebnisse in einer Web- oder mobilen Plattform 
+- Koordination Integrationstest zwischen den beteiligten Teams 
+
+**Tools** 
+- IntelliJ 
+- Java 
+- Cucumber / Cypress 
+- J-Meter / Gatling
+- CI/CD / GITLAB CI / Jenkins 
+- Helm / Docker 
+- JIRA / Confluence 
+- Kibana / Grafana / Instana / Graylog 
+- Behaviour Driven Development 
+- Consumer Driven Contracts (Spring Cloud Contract) 
+- Ionic (Hybride App) 
+- Selenium 
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Last und Perfomance Tests / Testautomatisierung / Testmanagement"
+        dates = "09/2015 - 01/2017"
+        company = "DB Systel"
+        details = """
+**Last und Performance Tests und Analyse - Testmanager, Testdesigner, Analyst** Entwicklung, Durchführung und Analyse von Last und Performance Tests 
+**Schwerpunkte** 
+- Anforderungs-Management 
+- Status Reports 
+- Beratung der Kunden 
+- Dokumentation in Form von Testkonzepten, Analysen, Management-Reporting und Wiki-Dokumentation 
+- Aufbau und Ausführung der Last und Performance Tests 
+- Analyse der Ergebnisse & Performance Logs
+
+**Tools** 
+- Visual Studio 
+- Eclipse 
+- JMeter 
+- GIT 
+- JIRA / Confluence 
+- Excel & Access VBS 
+- Schnittstellen: HTTP, WS, REST, MQ, JMS  
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Senior IOS Developer"
+        dates = "04/2015 - 09/2015"
+        company = "Telekom"
+        details = """
+**Senior IOS Developer** Weiterentwicklung der Rebuild Version der **Kundencenter App** der Deutschen Telekom, Erweiterung um neue Funktionalitäten zur IFA. 
+**Schwerpunkte** 
+- Swift 
+- IOS 8 
+- Requests & Responses to Backend 
+- Errorhandling 
+- Ipad / Iphone 
+- Scrum 
+
+**Tools** 
+- XCode 
+- GIT 
+- JIRA 
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "QS, Testmanagement"
+        dates = "05/2009 - 03/2015"
+        company = "Siemens"
+        details = """
+**QS, Testmanagement , Testautomatisierung, Requirements Engineering** Es wurden insgesamt 5 Projekte als QA & Testmanager begleitet und erfolgreich eingeführt 
+**Projekte** 
+- SIPCA - Verwaltungssystem für Mitarbeiter-Jahresziele und Berechnung der Bonuszahlungen 
+- STM - Antrag und Reisekostenerfassung (Frontend: Web / Backend SAP) 
+- GPM2 - Aktien-Bonus-Programm für Angestellte (Frontend: Web / Backend: JBoss) 
+- PATAC 
+- SOM - Verwaltung und Übersicht von OrgUnits 
+
+**Schwerpunkte** 
+- Erstellung fachlicher Testkonzepte und Testpläne 
+- Defect - Tracking 
+- Verwaltung der CRs, Kommunikation zwischen Kunden und Entwickler 
+- Erstellung, Pflege und Scheduling von Testautomatisierungen 
+- User Acceptance Tests 
+- Schulung neuer Tester und Testautomatisierer 
+- Betretung als Testmanager nach Projektschluss im Regelbetrieb 
+- Aufbau von Abnahme-Tests 
+- Übertragung der Fachspezifikation und Feinspezifikation ins Quality Center  
+- Überwachung der umgesetzten Anforderungen gegen das Feinkonzept 
+
+**Tools** 
+- HP ALM 
+- HP UFT 
+- HP QC 
+- Quick Test Pro  
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Last und Performance Tester"
+        dates = "03/2009 - 05/2009"
+        company = "ING-DIBA"
+        details = """
+**Last und Performance Tester** Ziel des Projektes ist die Konzeption und Entwicklung von LoadRunner-Scripts für den Lasttest von einem Bundle mit ca. 20 J2EE Applikationen in einem Bankportal 
+**Schwerpunkte** 
+- Erstellung von Testskripten in LoadRunner mit dem http-Protokoll  
+- Durchführung von Lasttests und Analyse der Ergebnisse 
+- Monitoring und Reporting 
+
+**Tools** 
+- Loadrunner 
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Zusammenfassung verschiedene Aktivitäten"
+        dates = "01/2006 - 12/2008"
+        company = "British Telecom, Mobiliar, DB-Systel, Sparkassen Informatik, Loyalty Partner, Telekom, Itelium, Deutsche Post, Postbank"
+        details = """
+**Last und Performance Tester / Tester** Verschiedene Projekte, überwiegend Last & Performance Tests
+**Schwerpunkte** 
+- Erstellung von Testskripten in LoadRunner mit dem http-Protokoll  
+- Durchführung von Lasttests und Analyse der Ergebnisse 
+- Monitoring und Reporting 
+
+**Tools** 
+- Loadrunner 
+        """
+
+      [languages.en]
+    languageCode = "en-us"
+    languageName = "English"
+    title = "Michael Boiman CV"
+    contentDir = "content/en"
+    weight = 2
+
+    [languages.en.params]
+      description = "CV of Michael Boiman"
+      author = "Michael Boiman"
+      styles = "styles-6.css"
+
+      [languages.en.params.profile]
+        name = "Michael Boiman"
+        tagline = "Full-Stack Dev & Quality Engineer – AI Automation Expert"
+        avatar = "profile.png"
+
+      [languages.en.params.contact]
+        enable = true
+
+        [[languages.en.params.contact.list]]
+        class = "email"
+        icon = "fa-envelope"
+        url = "mailto:mboiman@gmail.com"
+        title = "mboiman@gmail.com"
+
+        [[languages.en.params.contact.list]]
+        class = "phone"
+        icon = "fa-phone"
+        url = ""
+        title = "Available on request via email"
+
+        [[languages.en.params.contact.list]]
+        class = "website"
+        icon = "fa-globe"
+        url = "http://boiman-kupermann.com"
+        title = "BKS-Lab"
+
+        [[languages.en.params.contact.list]]
+        class = "linkedin"
+        icon = "fa-linkedin"
+        url = "//linkedin.com/in/michael-boiman-ab709912"
+        title = "michael-boiman"
+
+        [[languages.en.params.contact.list]]
+        class = "github"
+        icon = "fa-github"
+        url = "//github.com/bks-lab"
+        title = "GitHub Profile"
+
+        [[languages.en.params.contact.list]]
+        class = "twitter"
+        icon = "fa-twitter"
+        url = "//twitter.com/mboiman"
+        title = "@mboiman"
+
+      [languages.en.params.education]
+        enable = true
+        title = "Education"
+
+        [[languages.en.params.education.list]]
+        degree = "Diploma in Computer Science (UAS)"
+        college = "Cologne University of Applied Sciences, Gummersbach"
+        dates = "2000 – 2005"
+
+        [[languages.en.params.education.list]]
+        degree = "ISTQB Certified Tester"
+        dates = "2005"
+
+      [languages.en.params.language]
+        enable = true
+        title = "Languages"
+
+        [[languages.en.params.language.list]]
+        language = "German"
+        level = "Native"
+
+        [[languages.en.params.language.list]]
+        language = "English"
+        level = "Professional"
+
+        [[languages.en.params.language.list]]
+        language = "Russian"
+        level = "Conversational"
+
+        [[languages.en.params.language.list]]
+        language = "Hebrew"
+        level = "Conversational"
+
+      [languages.en.params.interests]
+        enable = false
+        title  = "Interests"
+
+        [[languages.en.params.interests.list]]
+        interest = "Gaming"
+
+        [[languages.en.params.interests.list]]
+        interest = "Basketball"
+
+      [languages.en.params.summary]
+        enable = true
+        icon = "fa-user"
+        title = "Career Profile"
+        summary = """\
+With more than 20 years of experience in software development, I focus on automating business and quality processes and integrating artificial intelligence. My professional strengths include:
+- **AI Automation**: Optimising and implementing AI within existing business processes.
+- **Python Expertise**: Extensive experience in developing AI-based solutions, automations, and data analysis using Python.
+- **Business-Process Automation**: Increasing efficiency by automating manual workflows and data processing.
+- **Development of an AI Mail Bot**: Automated email processing and data synchronisation with third-party systems.
+- **Experience with LLMs**: GPT, Claude, Gemini, Llama, Mistral, RAGs, Agentic AI, MCP, A2A, among others.
+- **Test Automation**: Setting up quality gates within the CI/CD pipeline.
+- **Real-Time Monitoring**: Building systems that display quality status in real time.
+- **ML and DL Models**: Integrating machine-learning and deep-learning models into business processes.
+- **Performance Testing**: Conducting load and performance tests.
+- **Development**: Expertise in Java, JavaScript, Swift, Python and other languages.
+- **DevOps**: Experience with GitHub, GitLab, Jenkins and other CI/CD tools.
+- **Contract Testing**: Using Pact.io or Spring Contract.
+- **Cloud Technologies**: Proficient with Kubernetes, Helm, Terraform, ArgoCD, etc.
+- **Mobile Development**: Solid experience building mobile apps with Swift and Flutter.
+- **Agile Methods**: Practical application of Scrum and SAFe.
+- **Team Leadership**: Managing and coordinating cross-functional teams."""
+
+      [languages.en.params.experiences]
+        enable = true
+        icon = "fa-briefcase"
+        title = "Professional Experience"
+
+        [[languages.en.params.jobs.list]]
+        position = "Quality Lead"
+        dates = "08/2021 – 05/2025"
+        company = "DVAG"
+        details = """
+**Test management & coordination**, as well as introduction of CI/CD with quality-gate setup. Acting as cross-team Quality Lead: onboarding, guidance, consulting and training for the introduction of quality metrics and test automation within the pipeline across teams.
+**Key responsibilities**
+- Design and implementation of functional and technical dashboards with Grafana for real-time quality measurement
+- Documentation of quality metrics covering the measurable sprint progress
+- Design and setup of CI/CD pipelines for multiple development teams (backend + frontend)
+- Introduction of quality gates to safeguard quality within the CI/CD pipeline
+- Adoption of Gauge (BDD)
+- Roll-out of Playwright and integration into the existing CI/CD pipeline
+- Functional and technical incident analysis
+- Consultancy, design and implementation of solutions for quality-related issues
+
+**Tools**
+- IntelliJ / Visual Studio Code
+- Java / JavaScript / TypeScript
+- Playwright / Gauge / Taiko / Karate
+- Python for processing and analysis of test and reporting data
+- CI/CD / GitHub – reusable workflows
+- Helm / Containers
+- JIRA / Confluence
+- Grafana
+- Behaviour-Driven Development
+- Consumer-Driven Contracts (Pact.io)
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "Technical Lead & Development"
+        dates    = "01/2024 – 04/2025"
+        company  = "BKS"
+        details  = """
+**Technical lead & development**: Design and implementation of a scalable automation solution for processing e‑invoices and PDF invoices fetched from a mailbox of a leading online job platform. Full responsibility from requirements analysis through implementation to production go‑live.
+
+**Focus areas**:
+- **Workflow automation**: Extraction, analysis and classification of incoming invoices using Python and Azure Functions.
+- **E‑invoice classification & data extraction**: Full processing in accordance with EU standard EN 16931 (ZUGFeRD, XRechnung), including structural and content parsing.
+- **Salesforce integration**: Forwarding prepared invoice data via email to the downstream system for Salesforce import.
+- **Auditing & logging**: Comprehensive documentation of all processing steps plus storage of original email content in the processing log.
+- **Outlook management & SharePoint archiving**: Automatic moving and categorising of emails into predefined Outlook folders; archiving of original and generated invoice documents via Microsoft Graph API.
+- **Monitoring & logging**: End‑to‑end real‑time monitoring with Kibana, including alerting and dashboard creation.
+- **Team coordination**: Managing the developer team incl. code reviews.
+
+**Tools & technologies**
+- Azure Functions: Serverless orchestration of automation workflows.
+- Python: Core logic for data extraction, classification and integration with automated CI/CD processes, packaging, and comprehensive unit and integration tests for quality assurance.
+- Microsoft Graph API: Access to Outlook mailboxes and SharePoint libraries.
+- GitHub: Version control, CI/CD pipelines and collaborative development.
+- Kibana: Monitoring, log analysis and performance dashboards.
+- Streamlit: For developing an interactive web application for visualization.
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "Project Management & Technical Lead"
+        dates = "04/2023 - 04/2024"
+        company = "Ryze"
+        details = """
+**Project management & technical lead**: Development and deployment of an AI-driven email bot to automate customer communication, AI-assisted processing of incoming emails and triggering of follow-up activities in existing SAP systems. Responsible for end-to-end project coordination and team management from idea to implementation.
+
+**Focus areas**:
+- **Development of ML models**: Design and training of specialized models for effective email classification, implemented via Azure Functions.
+- **API integrations**: Seamless connection to Microsoft Outlook 365 via Microsoft Graph API and to SAP systems for customer data checks.
+- **Process automation**: Automatic moving of emails based on classification and specific business rules, including complaint handling.
+- **DevOps and monitoring**: Implementation of CI/CD pipelines and use of Kibana for monitoring.
+- **Development of a Streamlit-based user interface**: Improved testability and visualization of process results.
+- **Team coaching**: Technical guidance for developers with regular code reviews and problem-solving sessions.
+
+**Tools & technologies**
+- Azure Functions: For serverless application architectures and ML model execution.
+- Python: Main programming language for the email bot and ML models.
+- Microsoft Graph API: For accessing and processing emails in Microsoft Outlook 365.
+- SAP API: For querying customer data and communicating with SAP systems.
+- GitHub: For version control, CI/CD pipelines and collaborative development.
+- Kibana: For real-time monitoring and system performance analysis.
+- Streamlit: For developing an interactive web application for system monitoring.
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "AI Workshop for Business Integration"
+        dates = "2023"
+        company = "Applications of AI in Business Context"
+        details = """
+**AI workshop**: Comprehensive presentation and live demonstration of innovative AI applications for business with a focus on practical implementation, theory and code examples.
+
+**Presentation content**
+- Comprehensive overview of AI fields and patterns (supervised/unsupervised/semi-supervised learning)
+- Deep dives into machine learning, deep learning and natural language processing
+- Detailed look at GPT models and their functionality (next token prediction)
+- Practical prompt engineering with examples for various use cases
+- Introduction to tools such as Hugging Face, Stable Diffusion, Midjourney and Auto-GPT
+
+**Practical workshop part**
+- Development of an intelligent Q&A bot with OpenAI GPT-3.5-Turbo
+- Live development of a web scraper for data acquisition
+- Extraction and vectorization of text embeddings with OpenAI models
+- Implementation of similarity search for context-based answers
+- Similarity analysis and visualization of results
+- Creation of an interactive Streamlit user interface for the Q&A bot
+
+**Technologies used**
+- OpenAI API (GPT-3.5-Turbo, Embedding-Ada-002)
+- Python with Pandas, NumPy and Streamlit
+- Vector embeddings and cosine similarity for semantic search
+- Web scraping with BeautifulSoup and Requests
+- Prompt engineering and AI integration into business processes
+- Integration via RESTful APIs
+
+The full presentation is available at [Pitch.com](https://pitch.com/public/bc7eaebb-5fb1-4e6f-bf84-ce9363c7abc0). The complete source code of the developed Q&A bot is documented in my [GitHub repository](https://github.com/boiman-solutions/workshop-q-a-scrap-bot).
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Quality Lead"
+        dates = "01/2017 - 05/2021"
+        company = "DB Vertrieb"
+        details = """
+**Test management, test coordination, test automation – agile (Kanban, Scrum, SAFe)**: Coordination as PO of a cross-team QA team including cross-team onboarding, support, consulting, training
+**Key responsibilities**
+- Agile quality assurance through the design of quality gates in the CI/CD pipeline
+- Design and implementation of functional and technical dashboards with Kibana, Graylog, Grafana, Instana & Elastic Search
+- Performance tests within CI/CD with Gatling / JMeter and analysis using Kibana, Graylog, Grafana and Instana
+- Documentation of quality metrics on the progress of measurable sprint quality
+- Design and setup of CI/CD pipelines for data tests
+- Functional and technical problem analysis
+- Consulting, design and implementation of solutions for quality-related issues
+- Setup of Junit, unit tests and integration tests, among others with Java Cucumber
+- Development of a hybrid app for presenting (reviewing) results on a web or mobile platform
+- Coordination of integration tests between the involved teams
+
+**Tools**
+- IntelliJ
+- Java
+- Cucumber / Cypress
+- J-Meter / Gatling
+- CI/CD / GitLab CI / Jenkins
+- Helm / Docker
+- JIRA / Confluence
+- Kibana / Grafana / Instana / Graylog
+- Behaviour Driven Development
+- Consumer Driven Contracts (Spring Cloud Contract)
+- Ionic (hybrid app)
+- Selenium
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Load and Performance Testing / Test Automation / Test Management"
+        dates = "09/2015 - 01/2017"
+        company = "DB Systel"
+        details = """
+**Load and performance tests and analysis – test manager, test designer, analyst**: Development, execution and analysis of load and performance tests
+**Key responsibilities**
+- Requirements management
+- Status reports
+- Customer consulting
+- Documentation in the form of test concepts, analyses, management reporting and wiki documentation
+- Setup and execution of load and performance tests
+- Analysis of results & performance logs
+
+**Tools**
+- Visual Studio
+- Eclipse
+- JMeter
+- Git
+- JIRA / Confluence
+- Excel & Access VBS
+- Interfaces: HTTP, WS, REST, MQ, JMS
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "Senior iOS Developer"
+        dates = "04/2015 - 09/2015"
+        company = "Telekom"
+        details = """
+**Senior iOS Developer**: Further development of the rebuilt version of Deutsche Telekom's **Customer Center App**, extension with new functionalities for IFA.
+**Key responsibilities**
+- Swift
+- iOS 8
+- Requests & responses to backend
+- Error handling
+- iPad / iPhone
+- Scrum
+
+**Tools**
+- Xcode
+- Git
+- JIRA
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "QA, Test Management"
+        dates = "05/2009 - 03/2015"
+        company = "Siemens"
+        details = """
+**QA, test management, test automation, requirements engineering**: A total of 5 projects were supported as QA & test manager and successfully implemented
+**Projects**
+- SIPCA - Management system for employee annual targets and bonus calculation
+- STM - Application and travel expense recording (Frontend: Web / Backend: SAP)
+- GPM2 - Share bonus program for employees (Frontend: Web / Backend: JBoss)
+- PATAC
+- SOM - Management and overview of OrgUnits
+
+**Key responsibilities**
+- Creation of technical test concepts and test plans
+- Defect tracking
+- Management of CRs, communication between customers and developers
+- Creation, maintenance and scheduling of test automation
+- User acceptance tests
+- Training of new testers and test automation engineers
+- Support as test manager after project completion in regular operation
+- Setup of acceptance tests
+- Transfer of functional specification and detailed specification to Quality Center
+- Monitoring of implemented requirements against the detailed concept
+
+**Tools**
+- HP ALM
+- HP UFT
+- HP QC
+- Quick Test Pro
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "Load and Performance Tester"
+        dates = "03/2009 - 05/2009"
+        company = "ING-DIBA"
+        details = """
+**Load and performance tester**: The goal of the project is the design and development of LoadRunner scripts for load testing a bundle of approx. 20 J2EE applications in a banking portal
+**Key responsibilities**
+- Creation of test scripts in LoadRunner with the http protocol
+- Execution of load tests and analysis of results
+- Monitoring and reporting
+
+**Tools**
+- LoadRunner
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "Summary of Various Activities"
+        dates = "01/2006 - 12/2008"
+        company = "British Telecom, Mobiliar, DB-Systel, Sparkassen Informatik, Loyalty Partner, Telekom, Itelium, Deutsche Post, Postbank"
+        details = """
+**Load and performance tester / tester**: Various projects, predominantly load & performance tests
+**Key responsibilities**
+- Creation of test scripts in LoadRunner with the http protocol
+- Execution of load tests and analysis of results
+- Monitoring and reporting
+
+**Tools**
+- LoadRunner
+        """
+
+      [languages.de.params.projects]
+        enable = true
+        icon = "fa-archive"
+        title = "NEBENPROJEKTE"
+        intro = "**Weitere Projekte außerhalb des Kerngeschäfts**"
+
+        [[languages.de.params.projects.list]]
+        title = "wecation"
+        url = "https://www.wecation.de"
+        tagline = "wecation ist eine kollaborative Lösung zur Organisation gemeinsamer Erlebnisse: Plane, suche, stimme dich mit deinen Freunden oder Kollegen kollaborativ ab und genießt gemeinsam das Erlebnis!"
+
+        [[languages.de.params.projects.list]]
+        title = "QualityCluster"
+        url = "https://qualitycluster.de"
+        tagline = """
+QualityCluster ist ein Zusammenschluss von Quality Engineers, um gemeinsam bessere Lösungen im Bereich Software Qualitätssicherung zu entwickeln. 
+Unser Ziel ist es, mehr Qualität durch höheren Automatisierungsgrad zu verwirklichen. 
+"""
+
+        [[languages.de.params.projects.list]]
+        title = "KI-basierter Chatbot für Messe-Interaktion"
+        url = "#"
+        tagline = "Entwicklung eines interaktiven Chatbots unter Verwendung von RAG und OpenAI, um die Benutzerinteraktion auf einer Messe-Website zu optimieren."
+
+        [[languages.de.params.projects.list]]
+        title = "Automatisierte NLP-Analyse von PDF-Dokumenten"
+        url = "#"
+        tagline = "Einsatz von NLP-Technologien zur Effizienzsteigerung in der automatisierten Dokumentenanalyse."
+
+        [[languages.de.params.projects.list]]
+        title = "E-Mail-Klassifizierung und -Verarbeitungsprozess"
+        url = "#"
+        tagline = "Integration von Microsoft Graph API, SAP, Azure Functions, REST-API, OpenAI, ElasticSearch und Kibana zur Optimierung der E-Mail-Verarbeitung."
+
+        [[languages.de.params.projects.list]]
+        title   = "MCP - Model Context Protokoll"
+        url     = "#"
+        tagline = "Umsetzung verschiedener Tools zur Modell-Kontext-Orchestrierung."
+
+        [[languages.de.params.projects.list]]
+        title   = "AI-Automatisierungs-Functionsbausteine"
+        url     = "#"
+        tagline = "Aufbau von Functions-Bausteinen zur schnelleren Einführung von AI-Automatisierung."
+
+        [[languages.de.params.projects.list]]
+        title   = "AI-Beratung für Unternehmen"
+        url     = "#"
+        tagline = "Beratungen zum Einsatz von AI im Unternehmen."
+
+      [languages.en.params.projects]
+        enable = true
+        icon = "fa-archive"
+        title = "PROJECTS"
+        intro = "**Additional projects outside the core business**"
+
+        [[languages.en.params.projects.list]]
+        title = "wecation"
+        url = "https://www.wecation.de"
+        tagline = "wecation is a collaborative solution for organising shared experiences: plan, search, coordinate with friends or colleagues and enjoy the activity together!"
+
+        [[languages.en.params.projects.list]]
+        title = "QualityCluster"
+        url = "https://qualitycluster.de"
+        tagline = """
+QualityCluster is an alliance of quality engineers jointly developing better solutions in software quality assurance.  
+Our goal is to implement more quality through a higher degree of automation.  
+"""
+
+        [[languages.en.params.projects.list]]
+        title = "AI-Driven Chatbot for Trade-Fair Interaction"
+        url = "#"
+        tagline = "Development of an interactive chatbot using RAG and OpenAI to optimise user interaction on a trade-fair website."
+
+        [[languages.en.params.projects.list]]
+        title = "Automated NLP Analysis of PDF Documents"
+        url = "#"
+        tagline = "Using NLP technologies to boost efficiency in automated document analysis."
+
+        [[languages.en.params.projects.list]]
+        title = "Email Classification and Processing Workflow"
+        url = "#"
+        tagline = "Integration of Microsoft Graph API, SAP, Azure Functions, REST API, OpenAI, Elasticsearch and Kibana to optimise email processing."
+
+        [[languages.en.params.projects.list]]
+        title = "MCP – Model Context Protocol"
+        url = "#"
+        tagline = "Implementation of various tools for model-context orchestration."
+
+        [[languages.en.params.projects.list]]
+        title = "AI Automation Function Modules"
+        url = "#"
+        tagline = "Building function modules for faster rollout of AI automation."
+
+        [[languages.en.params.projects.list]]
+        title = "AI Consulting for Enterprises"
+        url = "#"
+        tagline = "Consultancy on the use of AI within companies."
+
+      [languages.de.params.skills]
+        enable = true
+        icon = "fa-rocket"
+        title = "Skills & Tools"
+
+        [[languages.de.params.skills.list]]
+        skill = "Python (Datenanalyse, ML/AI, Automatisierung)"
+        level = "98%"
+        
+        [[languages.de.params.skills.list]]
+        skill = "AI & Machine Learning"
+        level = "96%"
+
+        [[languages.de.params.skills.list]]
+        skill = "Software-Entwicklung, -Design, -Architektur"
+        level = "99%"
+
+        [[languages.de.params.skills.list]]
+        skill = "Jira & Confluence"
+        level = "98%"
+                
+        [[languages.de.params.skills.list]]
+        skill = "IntelliJ & VS Code"
+        level = "93%"
+
+        [[languages.de.params.skills.list]]
+        skill = "Playwright"
+        level = "97%"
+
+        [[languages.de.params.skills.list]]
+        skill = "Cucumber / Gauge / Taiko"
+        level = "99%"
+
+        [[languages.de.params.skills.list]]
+        skill = "CDC - Spring Contract & Pact.io"
+        level = "70%"
+
+        [[languages.de.params.skills.list]]
+        skill = "CI/CD-Workflows - Gitlab & Github & Jenkins"
+        level = "90%"
+
+        [[languages.de.params.skills.list]]
+        skill = "Kubernetes - Helm & Terraform & ArgoCD"
+        level = "80%"
+
+        [[languages.de.params.skills.list]]
+        skill = "REST & Postman"
+        level = "95%"
+
+        [[languages.de.params.skills.list]]
+        skill = "Last und Performance Testing mit J-Meter, Gatling"
+        level = "90%"
+
+        [[languages.de.params.skills.list]]
+        skill = "AWS & Google & Azure"
+        level = "80%"
+
+        [[languages.de.params.skills.list]]
+        skill = """
+        Dashboards & Analyse - \n
+        Kibana(+ES) & Greylog &  \n
+        Grafana & Instana 
+        """
+        level = "90%"
+
+        [[languages.de.params.skills.list]]
+        skill = "MobileDev - X-Code & Flutter & Swift"
+        level = "90%"
+
+      [languages.en.params.skills]
+        enable = true
+        icon = "fa-rocket"
+        title = "SKILLS & TOOLS"
+
+        [[languages.en.params.skills.list]]
+        skill = "Python (Data Analysis, ML/AI, Automation)"
+        level = "98%"
+        
+        [[languages.en.params.skills.list]]
+        skill = "AI & Machine Learning"
+        level = "96%"
+        
+        [[languages.en.params.skills.list]]
+        skill = "Software Development, Design, Architecture"
+        level = "99%"
+
+        [[languages.en.params.skills.list]]
+        skill = "JIRA & Confluence"
+        level = "98%"
+
+        [[languages.en.params.skills.list]]
+        skill = "IntelliJ & VS Code"
+        level = "93%"
+
+        [[languages.en.params.skills.list]]
+        skill = "Playwright"
+        level = "97%"
+
+        [[languages.en.params.skills.list]]
+        skill = "Cucumber / Gauge / Taiko"
+        level = "99%"
+
+        [[languages.en.params.skills.list]]
+        skill = "CDC – Spring Contract & Pact.io"
+        level = "70%"
+
+        [[languages.en.params.skills.list]]
+        skill = "CI/CD Workflows – GitLab, GitHub & Jenkins"
+        level = "90%"
+
+        [[languages.en.params.skills.list]]
+        skill = "Kubernetes – Helm, Terraform & ArgoCD"
+        level = "80%"
+
+        [[languages.en.params.skills.list]]
+        skill = "REST & Postman"
+        level = "95%"
+
+        [[languages.en.params.skills.list]]
+        skill = "Load & Performance Testing with JMeter, Gatling"
+        level = "90%"
+
+        [[languages.en.params.skills.list]]
+        skill = "AWS, Google Cloud & Azure"
+        level = "80%"
+
+        [[languages.en.params.skills.list]]
+        skill = """
+Dashboards & Analytics –  
+Kibana (+ES) & Graylog &  
+Grafana & Instana
+        """
+        level = "90%"
+
+        [[languages.en.params.skills.list]]
+        skill = "Mobile Dev – Xcode, Flutter & Swift"
+        level = "90%"
+
+      [languages.de.params.footer]
+        copyright = "Michael.Boiman"

--- a/config.cv.toml
+++ b/config.cv.toml
@@ -1,0 +1,1015 @@
+# Page settings
+
+baseurl = "https://mboiman.github.io/"
+languageCode = "de-de"
+title = "Michael Boiman CV"
+theme = "my-hugo-orbit-theme"
+#googleAnalytics = "UA-XXXXXXX-Y"
+
+# Do not build files for websites. Need them? Set to false
+disableRSS = true
+disableSitemap = true
+disable404 = true
+
+
+
+# Mehrsprachige Konfiguration
+defaultContentLanguage = "de"
+defaultContentLanguageInSubdir = true
+
+[languages]
+  [languages.de]
+    languageCode = "de-de"
+    languageName = "Deutsch"
+    title = "Michael Boiman CV"
+    contentDir = "content/de"
+    weight = 1
+
+    [languages.de.params]
+      description = "Lebenslauf von Michael Boiman"
+      author = "Michael Boiman"
+      styles = "styles-6.css"
+
+      [languages.de.params.profile]
+        name = "Michael Boiman"
+        tagline = "Full-Stack Dev & Quality Engineer – KI-Automatisierungsexperte"
+        avatar = "profile.png"
+
+      [languages.de.params.contact]
+        enable = true
+
+        [[languages.de.params.contact.list]]
+        class = "email"
+        icon = "fa-envelope"
+        url = "mailto:mboiman@gmail.com"
+        title = "mboiman@gmail.com"
+
+        [[languages.de.params.contact.list]]
+        class = "phone"
+        icon = "fa-phone"
+        url = ""
+        title = "Auf Anfrage per E-Mail verfügbar"
+
+        [[languages.de.params.contact.list]]
+        class = "website"
+        icon = "fa-globe"
+        url = "http://boiman-kupermann.com"
+        title = "BKS-Lab"
+
+        [[languages.de.params.contact.list]]
+        class = "linkedin"
+        icon = "fa-linkedin"
+        url = "//linkedin.com/in/michael-boiman-ab709912"
+        title = "michael-boiman"
+
+        [[languages.de.params.contact.list]]
+        class = "github"
+        icon = "fa-github"
+        url = "//github.com/bks-lab"
+        title = "GitHub Profil"
+
+        [[languages.de.params.contact.list]]
+        class = "twitter"
+        icon = "fa-twitter"
+        url = "//twitter.com/mboiman"
+        title = "@mboiman"
+
+      [languages.de.params.education]
+        enable = true
+        title = "Ausbildung"
+
+        [[languages.de.params.education.list]]
+        degree = "Diplom-Informatiker (FH)"
+        college = "Fachhochschule Köln, Gummersbach"
+        dates = "2000 – 2005"
+
+        [[languages.de.params.education.list]]
+        degree = "ISTQB Certified Tester"
+        dates = "2005"
+
+      [languages.de.params.language]
+        enable = true
+        title = "Sprachen"
+
+        [[languages.de.params.language.list]]
+        language = "Deutsch"
+        level = "Muttersprache"
+
+        [[languages.de.params.language.list]]
+        language = "Englisch"
+        level = "Fließend"
+
+        [[languages.de.params.language.list]]
+        language = "Russisch"
+        level = "Konversationslevel"
+
+        [[languages.de.params.language.list]]
+        language = "Hebräisch"
+        level = "Konversationslevel"
+
+      [languages.de.params.interests]
+        enable = false
+        title  = "Interessen"
+
+        [[languages.de.params.interests.list]]
+        interest = "Gaming"
+
+        [[languages.de.params.interests.list]]
+        interest = "Basketball"
+
+      [languages.de.params.summary]
+        enable = true
+        icon = "fa-user"
+        title = "Karriereprofil"
+        summary = """\
+Mit mehr als 20 Jahren Erfahrung in der Softwareentwicklung liegt mein Fokus auf der Automatisierung von Geschäfts- und Qualitätsprozessen sowie der Integration künstlicher Intelligenz. Zu meinen fachlichen Schwerpunkten zählen:
+- **KI-Automatisierung**: Optimierung und Implementierung von KI in bestehende Geschäftsprozesse.
+- **Python-Expertise**: Umfassende Erfahrung in der Entwicklung von KI-basierten Lösungen, Automatisierungen und Datenanalysen mit Python.
+- **Geschäftsprozess-Automatisierung**: Effizienzsteigerung durch Automatisierung manueller Abläufe und Datenverarbeitung.
+- **Entwicklung eines KI-Mail-Bots**: Automatisierte E-Mail-Verarbeitung und Datenabgleich mit Drittsystemen.
+- **Erfahrung mit LLMs**: Einsatz von GPT, Claude, Gemini, Llama, Mistral, RAGs, Agentic AI, MCP, A2A u.a.
+- **Testautomatisierung**: Einrichtung von Quality-Gates innerhalb der CI/CD-Pipeline.
+- **Echtzeit-Monitoring**: Entwicklung von Systemen zur Darstellung des Qualitätsstands in Echtzeit.
+- **ML und DL-Modelle**: Integration von Machine Learning und Deep Learning in Geschäftsprozesse.
+- **Performance-Tests**: Durchführung von Last- und Performance-Tests.
+- **Entwicklung**: Expertise in Java, JavaScript, Swift, Python und weiteren Sprachen.
+- **DevOps**: Erfahrung mit GitHub, GitLab, Jenkins und anderen CI/CD-Tools.
+- **Contract-Testing**: Anwendung von Pact.io oder Spring Contract.
+- **Cloud-Technologien**: Kenntnisse in Kubernetes, Helm, Terraform, ArgoCD u.a.
+- **Mobile Entwicklung**: Fundierte Erfahrungen in der Entwicklung mobiler Anwendungen mit Swift und Flutter.
+- **Agile Methoden**: Praktische Anwendung von Scrum und SAFE.
+- **Teamleitung**: Leitung und Koordination von interdisziplinären Teams.
+        """
+
+      [languages.de.params.experiences]
+        enable = true
+        icon = "fa-briefcase"
+        title = "Berufserfahrung"
+
+        [[languages.de.params.jobs.list]]
+        position = "Quality Lead"
+        dates = "08/2021 – 05/2025"
+        company = "DVAG"
+        details = """
+**Testmanagement & Testkoordination**, sowie Einführung von CICD mit Aufbau von QualityGates** Koordination als Quality-Lead (übergreifendes QA-Team) inklusive Einarbeitung, Hilfestellung, Beratung, Schulung zur Einführung von Qualitätsmetriken und Testautomatisierung innerhalb der Pipeline, Teamübergreifend 
+**Schwerpunkte** 
+- Konzeption und Aufbau vom fachlichen und technischen Dashboards mit Grafana zur Echtzeitmessung der Qualität 
+- Dokumentation von Qualitätsmetriken über Fortschritt der messbaren Qualität der Sprints 
+- Aufbau und Konzeption einer CICD-Pipeline für verschiedene Entwicklungs-Teams (Backend + Frontend) 
+- Einführung von QualityGates zur Sicherung der Qualität innerhalb der CICD-Pipeline
+- Einführung von Gauge (BDD) 
+- Einführung von Playwright und Integration in bestehende CICD-Pipeline
+- Fachliche und technische Analyse von Incidents 
+- Beratung sowie Konzeption und Umsetzung von Lösungen für qualitäts-relevante Probleme 
+
+**Tools** 
+- IntelliJ / Visual Studio Code 
+- Java / Java-Script / Typescript 
+- Playwright / Gauge / Taiko / Karate 
+- Python für die Aufbereitung und Analyse von Test- und Reportdaten
+- CI/CD / Github – reuseable workflows 
+- Helm / Container 
+- JIRA / Confluence 
+- Grafana 
+- Behavioral-Driven Development 
+- Consumer Driven Contracts (Pact.io) 
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Technische Leitung & Entwicklung"
+        dates    = "01/2024 – 04/2025"
+        company  = "BKS"
+        details  = """
+**Technische Leitung & Entwicklung**: Konzeption und Umsetzung einer skalierbaren Automatisierungslösung für die Verarbeitung von E-Rechnungen und PDF-Rechnungen aus dem Postfach einer führenden Online-Jobplattform. Vollständige Verantwortung von der Anforderungsanalyse über die Implementierung bis zur Produktionseinführung.
+
+**Schwerpunkte**:
+- **Workflow-Automatisierung**: Extraktion, Analyse und Klassifizierung eingehender Rechnungen mittels Python und Azure Functions.
+- **E-Rechnungs-Klassifizierung & Daten-Extraction**: Vollständige Verarbeitung nach EU-Standards (EN 16931: ZUGFeRD, XRechnung), inklusive Struktur- und Inhalts-Parsing.
+- **Salesforce-Einspielung**: Weiterleitung der aufbereiteten Rechnungsdaten per E-Mail an das nachgelagerte System für den Salesforce-Import.
+- **Auditierung & Protokollierung**: Lückenlose Dokumentation aller Verarbeitungsschritte sowie Speicherung der ursprünglichen E-Mail-Inhalte im Verarbeitungsprotokoll.
+- **Outlook-Management & SharePoint-Archivierung**: Automatisches Verschieben und Kategorisieren von E-Mails in vordefinierte Zielordner in Outlook; Archivierung von Original- und generierten Rechnungsdokumenten über Microsoft Graph API.
+- **Monitoring & Logging**: Echtzeit-Überwachung des End-to-End-Prozesses mit Kibana, inklusive Alerting und Dashboard-Erstellung.
+- **Team-Koordination**: Steuerung des Entwickler-Teams inkl. Code-Reviews.
+
+**Tools & Technologien**
+- Azure Functions: Serverlose Orchestrierung der Automatisierungs-Workflows.
+- Python: Implementierung der Kernlogik für Datenextraktion, Klassifizierung und Integration mit automatisierten CI/CD-Prozessen, Paketierung und umfassenden Unit- sowie Integrationstests zur Qualitätssicherung.
+- Microsoft Graph API: Zugriff auf Outlook-Postfächer und SharePoint-Dokumentbibliotheken.
+- GitHub: Versionskontrolle, CI/CD-Pipelines und kollaborative Entwicklung.
+- Kibana: Monitoring, Log-Analyse und Performance-Dashboards.
+- Streamlit: Für die Entwicklung einer interaktiven Webanwendung zur Visualisierung.
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Technische Leitung & Entwicklung"
+        dates = "04/2023 - 04/2024"
+        company = "Ryze"
+        details = """
+**Projektmanagement & Technische Leitung**: Entwicklung und Einführung eines KI-gesteuerten E-Mail-Bots zur Automatisierung der Kundenkommunikation, KI-gestützte Verarbeitung eingehender E-Mails und Auslösen von Folge-Aktivitäten in bestehenden SAP-Systeme. Verantwortlich für die End-to-End-Projektkoordination und Teamsteuerung von der Idee bis zur Implementierung.
+
+**Schwerpunkte**:
+- **Entwicklung von ML-Modellen**: Entwurf und Training spezialisierter Modelle zur effektiven Klassifizierung von E-Mails, realisiert durch Azure Functions.
+- **API-Integrationen**: Nahtlose Anbindung an Microsoft Outlook 365 über die Microsoft Graph API und an SAP-Systeme zur Überprüfung von Kundendaten.
+- **Prozessautomatisierung**: Automatisches Verschieben von E-Mails basierend auf Klassifikation und spezifischen Geschäftsregeln, inklusive der Bearbeitung von Reklamationen.
+- **DevOps und Monitoring**: Implementierung von CI/CD Pipelines sowie Einsatz von Kibana für das Monitoring.
+- **Entwicklung einer Streamlit-basierten Benutzeroberfläche**: Verbesserung der Testbarkeit und Visualisierung von Prozessergebnissen.
+- **Team-Betreuung**: Technische Anleitung der Entwickler mit regelmäßigen Code-Reviews und Problemlösungssessions.
+
+**Tools & Technologien**
+- Azure Functions: Für serverlose Anwendungsarchitekturen und die Ausführung von ML-Modellen.
+- Python: Hauptprogrammiersprache für die Entwicklung des E-Mail-Bots und der ML-Modelle.
+- Microsoft Graph API: Für den Zugriff und die Verarbeitung von E-Mails im Microsoft Outlook 365.
+- SAP API: Für die Abfrage von Kundendaten und die Kommunikation mit SAP-Systemen.
+- GitHub: Für Versionskontrolle, CI/CD Pipelines und den kollaborativen Entwicklungsprozess.
+- Kibana: Für das Echtzeit-Monitoring und die Analyse der Systemleistung.
+- Streamlit: Für die Entwicklung einer interaktiven Webanwendung zur Systemüberwachung.
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Anwendungen von KI im Geschäftsumfeld"
+        dates = "2023"
+        company = "KI-Workshop zur Unternehmenseinbindung"
+        details = """
+**KI-Workshop** Umfassende Präsentation und Live-Demonstration innovativer KI-Anwendungen für die Geschäftswelt mit Fokus auf praktische Umsetzung, Theorie und Code-Beispiele
+
+**Präsentationsinhalte**
+- Umfassender Überblick über KI-Bereiche und -Patterns (Supervised/Unsupervised/Semi-Supervised Learning)
+- Vertiefte Einblicke in Machine Learning, Deep Learning und Natural Language Processing
+- Detaillierte Betrachtung von GPT-Modellen und deren Funktionsweise (Next Token Prediction)
+- Praktisches Prompt Engineering mit Beispielen für verschiedene Anwendungsfälle
+- Vorstellung von Tools wie Hugging Face, Stable Diffusion, Midjourney und Auto-GPT
+
+**Praktischer Workshop-Teil**
+- Entwicklung eines intelligenten Q&A-Bots mit OpenAI GPT-3.5-Turbo
+- Live-Entwicklung eines Webscrapers zur Datenakquise
+- Extraktion und Vektorisierung von Text-Embeddings mit OpenAI-Modellen
+- Implementierung von Similarity Search für kontextbezogene Antworten
+- Ähnlichkeitsanalyse und Visualisierung der Ergebnisse
+- Erstellung einer interaktiven Streamlit-Benutzeroberfläche für den Q&A-Bot
+
+**Eingesetzte Technologien**
+- OpenAI API (GPT-3.5-Turbo, Embedding-Ada-002)
+- Python mit Pandas, NumPy und Streamlit
+- Vector Embeddings und Cosine-Similarity für semantische Suche
+- Web-Scraping mit BeautifulSoup und Requests
+- Prompt Engineering und KI-Integration in Geschäftsprozesse
+- Integration über RESTful APIs
+
+Die vollständige Präsentation ist unter [Pitch.com](https://pitch.com/public/bc7eaebb-5fb1-4e6f-bf84-ce9363c7abc0) verfügbar. Der komplette Quellcode des entwickelten Q&A-Bots ist in meinem [GitHub-Repository](https://github.com/boiman-solutions/workshop-q-a-scrap-bot) dokumentiert.
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Quality-Lead"
+        dates = "01/2017 - 05/2021"
+        company = "DB Vertrieb"
+        details = """
+**Testmanagement, Testkoordination, Testautomatisierung - Agil (Kanban, Scrum, SAFE)** Koordination als PO eines übergreifendes QA-Teams inklusive teamübergreifender Einarbeitung, Hilfestellung, Beratung, Schulung 
+**Schwerpunkte** 
+- Agile Qualitätssicherung durch Konzeption von QualityGates in der CI/CD Pipeline 
+- Konzeption und Aufbau vom fachlichen und technischen Dashboards mit Kibana, Graylog, Grafana, Instana & Elastic Search 
+- Performance Tests innerhalb der CI/CD mit Gatling / JMeter und Analyse mittels Kibana, Graylog, Grafana und Instana 
+- Dokumentation von Qualitätsmetriken über Fortschritt der messbaren Qualität der Sprints 
+- Aufbau und Konzeption von CI/CD-Pipeline für Daten-Tests 
+- Fachliche und technische Analyse von Problemen 
+- Beratung sowie Konzeption und Umsetzung von Lösungen für qualitäts-relevante Probleme 
+- Aufbau von Junit, Unit-Tests und Integrationstests unter anderen mit Java Cucumber 
+- Entwicklung einer hybriden App zur Präsentation (Review) der Ergebnisse in einer Web- oder mobilen Plattform 
+- Koordination Integrationstest zwischen den beteiligten Teams 
+
+**Tools** 
+- IntelliJ 
+- Java 
+- Cucumber / Cypress 
+- J-Meter / Gatling
+- CI/CD / GITLAB CI / Jenkins 
+- Helm / Docker 
+- JIRA / Confluence 
+- Kibana / Grafana / Instana / Graylog 
+- Behaviour Driven Development 
+- Consumer Driven Contracts (Spring Cloud Contract) 
+- Ionic (Hybride App) 
+- Selenium 
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Last und Perfomance Tests / Testautomatisierung / Testmanagement"
+        dates = "09/2015 - 01/2017"
+        company = "DB Systel"
+        details = """
+**Last und Performance Tests und Analyse - Testmanager, Testdesigner, Analyst** Entwicklung, Durchführung und Analyse von Last und Performance Tests 
+**Schwerpunkte** 
+- Anforderungs-Management 
+- Status Reports 
+- Beratung der Kunden 
+- Dokumentation in Form von Testkonzepten, Analysen, Management-Reporting und Wiki-Dokumentation 
+- Aufbau und Ausführung der Last und Performance Tests 
+- Analyse der Ergebnisse & Performance Logs
+
+**Tools** 
+- Visual Studio 
+- Eclipse 
+- JMeter 
+- GIT 
+- JIRA / Confluence 
+- Excel & Access VBS 
+- Schnittstellen: HTTP, WS, REST, MQ, JMS  
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Senior IOS Developer"
+        dates = "04/2015 - 09/2015"
+        company = "Telekom"
+        details = """
+**Senior IOS Developer** Weiterentwicklung der Rebuild Version der **Kundencenter App** der Deutschen Telekom, Erweiterung um neue Funktionalitäten zur IFA. 
+**Schwerpunkte** 
+- Swift 
+- IOS 8 
+- Requests & Responses to Backend 
+- Errorhandling 
+- Ipad / Iphone 
+- Scrum 
+
+**Tools** 
+- XCode 
+- GIT 
+- JIRA 
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "QS, Testmanagement"
+        dates = "05/2009 - 03/2015"
+        company = "Siemens"
+        details = """
+**QS, Testmanagement , Testautomatisierung, Requirements Engineering** Es wurden insgesamt 5 Projekte als QA & Testmanager begleitet und erfolgreich eingeführt 
+**Projekte** 
+- SIPCA - Verwaltungssystem für Mitarbeiter-Jahresziele und Berechnung der Bonuszahlungen 
+- STM - Antrag und Reisekostenerfassung (Frontend: Web / Backend SAP) 
+- GPM2 - Aktien-Bonus-Programm für Angestellte (Frontend: Web / Backend: JBoss) 
+- PATAC 
+- SOM - Verwaltung und Übersicht von OrgUnits 
+
+**Schwerpunkte** 
+- Erstellung fachlicher Testkonzepte und Testpläne 
+- Defect - Tracking 
+- Verwaltung der CRs, Kommunikation zwischen Kunden und Entwickler 
+- Erstellung, Pflege und Scheduling von Testautomatisierungen 
+- User Acceptance Tests 
+- Schulung neuer Tester und Testautomatisierer 
+- Betretung als Testmanager nach Projektschluss im Regelbetrieb 
+- Aufbau von Abnahme-Tests 
+- Übertragung der Fachspezifikation und Feinspezifikation ins Quality Center  
+- Überwachung der umgesetzten Anforderungen gegen das Feinkonzept 
+
+**Tools** 
+- HP ALM 
+- HP UFT 
+- HP QC 
+- Quick Test Pro  
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Last und Performance Tester"
+        dates = "03/2009 - 05/2009"
+        company = "ING-DIBA"
+        details = """
+**Last und Performance Tester** Ziel des Projektes ist die Konzeption und Entwicklung von LoadRunner-Scripts für den Lasttest von einem Bundle mit ca. 20 J2EE Applikationen in einem Bankportal 
+**Schwerpunkte** 
+- Erstellung von Testskripten in LoadRunner mit dem http-Protokoll  
+- Durchführung von Lasttests und Analyse der Ergebnisse 
+- Monitoring und Reporting 
+
+**Tools** 
+- Loadrunner 
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Zusammenfassung verschiedene Aktivitäten"
+        dates = "01/2006 - 12/2008"
+        company = "British Telecom, Mobiliar, DB-Systel, Sparkassen Informatik, Loyalty Partner, Telekom, Itelium, Deutsche Post, Postbank"
+        details = """
+**Last und Performance Tester / Tester** Verschiedene Projekte, überwiegend Last & Performance Tests
+**Schwerpunkte** 
+- Erstellung von Testskripten in LoadRunner mit dem http-Protokoll  
+- Durchführung von Lasttests und Analyse der Ergebnisse 
+- Monitoring und Reporting 
+
+**Tools** 
+- Loadrunner 
+        """
+
+      [languages.en]
+    languageCode = "en-us"
+    languageName = "English"
+    title = "Michael Boiman CV"
+    contentDir = "content/en"
+    weight = 2
+
+    [languages.en.params]
+      description = "CV of Michael Boiman"
+      author = "Michael Boiman"
+      styles = "styles-6.css"
+
+      [languages.en.params.profile]
+        name = "Michael Boiman"
+        tagline = "Full-Stack Dev & Quality Engineer – AI Automation Expert"
+        avatar = "profile.png"
+
+      [languages.en.params.contact]
+        enable = true
+
+        [[languages.en.params.contact.list]]
+        class = "email"
+        icon = "fa-envelope"
+        url = "mailto:mboiman@gmail.com"
+        title = "mboiman@gmail.com"
+
+        [[languages.en.params.contact.list]]
+        class = "phone"
+        icon = "fa-phone"
+        url = ""
+        title = "Available on request via email"
+
+        [[languages.en.params.contact.list]]
+        class = "website"
+        icon = "fa-globe"
+        url = "http://boiman-kupermann.com"
+        title = "BKS-Lab"
+
+        [[languages.en.params.contact.list]]
+        class = "linkedin"
+        icon = "fa-linkedin"
+        url = "//linkedin.com/in/michael-boiman-ab709912"
+        title = "michael-boiman"
+
+        [[languages.en.params.contact.list]]
+        class = "github"
+        icon = "fa-github"
+        url = "//github.com/bks-lab"
+        title = "GitHub Profile"
+
+        [[languages.en.params.contact.list]]
+        class = "twitter"
+        icon = "fa-twitter"
+        url = "//twitter.com/mboiman"
+        title = "@mboiman"
+
+      [languages.en.params.education]
+        enable = true
+        title = "Education"
+
+        [[languages.en.params.education.list]]
+        degree = "Diploma in Computer Science (UAS)"
+        college = "Cologne University of Applied Sciences, Gummersbach"
+        dates = "2000 – 2005"
+
+        [[languages.en.params.education.list]]
+        degree = "ISTQB Certified Tester"
+        dates = "2005"
+
+      [languages.en.params.language]
+        enable = true
+        title = "Languages"
+
+        [[languages.en.params.language.list]]
+        language = "German"
+        level = "Native"
+
+        [[languages.en.params.language.list]]
+        language = "English"
+        level = "Professional"
+
+        [[languages.en.params.language.list]]
+        language = "Russian"
+        level = "Conversational"
+
+        [[languages.en.params.language.list]]
+        language = "Hebrew"
+        level = "Conversational"
+
+      [languages.en.params.interests]
+        enable = false
+        title  = "Interests"
+
+        [[languages.en.params.interests.list]]
+        interest = "Gaming"
+
+        [[languages.en.params.interests.list]]
+        interest = "Basketball"
+
+      [languages.en.params.summary]
+        enable = true
+        icon = "fa-user"
+        title = "Career Profile"
+        summary = """\
+With more than 20 years of experience in software development, I focus on automating business and quality processes and integrating artificial intelligence. My professional strengths include:
+- **AI Automation**: Optimising and implementing AI within existing business processes.
+- **Python Expertise**: Extensive experience in developing AI-based solutions, automations, and data analysis using Python.
+- **Business-Process Automation**: Increasing efficiency by automating manual workflows and data processing.
+- **Development of an AI Mail Bot**: Automated email processing and data synchronisation with third-party systems.
+- **Experience with LLMs**: GPT, Claude, Gemini, Llama, Mistral, RAGs, Agentic AI, MCP, A2A, among others.
+- **Test Automation**: Setting up quality gates within the CI/CD pipeline.
+- **Real-Time Monitoring**: Building systems that display quality status in real time.
+- **ML and DL Models**: Integrating machine-learning and deep-learning models into business processes.
+- **Performance Testing**: Conducting load and performance tests.
+- **Development**: Expertise in Java, JavaScript, Swift, Python and other languages.
+- **DevOps**: Experience with GitHub, GitLab, Jenkins and other CI/CD tools.
+- **Contract Testing**: Using Pact.io or Spring Contract.
+- **Cloud Technologies**: Proficient with Kubernetes, Helm, Terraform, ArgoCD, etc.
+- **Mobile Development**: Solid experience building mobile apps with Swift and Flutter.
+- **Agile Methods**: Practical application of Scrum and SAFe.
+- **Team Leadership**: Managing and coordinating cross-functional teams."""
+
+      [languages.en.params.experiences]
+        enable = true
+        icon = "fa-briefcase"
+        title = "Professional Experience"
+
+        [[languages.en.params.jobs.list]]
+        position = "Quality Lead"
+        dates = "08/2021 – 05/2025"
+        company = "DVAG"
+        details = """
+**Test management & coordination**, as well as introduction of CI/CD with quality-gate setup. Acting as cross-team Quality Lead: onboarding, guidance, consulting and training for the introduction of quality metrics and test automation within the pipeline across teams.
+**Key responsibilities**
+- Design and implementation of functional and technical dashboards with Grafana for real-time quality measurement
+- Documentation of quality metrics covering the measurable sprint progress
+- Design and setup of CI/CD pipelines for multiple development teams (backend + frontend)
+- Introduction of quality gates to safeguard quality within the CI/CD pipeline
+- Adoption of Gauge (BDD)
+- Roll-out of Playwright and integration into the existing CI/CD pipeline
+- Functional and technical incident analysis
+- Consultancy, design and implementation of solutions for quality-related issues
+
+**Tools**
+- IntelliJ / Visual Studio Code
+- Java / JavaScript / TypeScript
+- Playwright / Gauge / Taiko / Karate
+- Python for processing and analysis of test and reporting data
+- CI/CD / GitHub – reusable workflows
+- Helm / Containers
+- JIRA / Confluence
+- Grafana
+- Behaviour-Driven Development
+- Consumer-Driven Contracts (Pact.io)
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "Technical Lead & Development"
+        dates    = "01/2024 – 04/2025"
+        company  = "BKS"
+        details  = """
+**Technical lead & development**: Design and implementation of a scalable automation solution for processing e‑invoices and PDF invoices fetched from a mailbox of a leading online job platform. Full responsibility from requirements analysis through implementation to production go‑live.
+
+**Focus areas**:
+- **Workflow automation**: Extraction, analysis and classification of incoming invoices using Python and Azure Functions.
+- **E‑invoice classification & data extraction**: Full processing in accordance with EU standard EN 16931 (ZUGFeRD, XRechnung), including structural and content parsing.
+- **Salesforce integration**: Forwarding prepared invoice data via email to the downstream system for Salesforce import.
+- **Auditing & logging**: Comprehensive documentation of all processing steps plus storage of original email content in the processing log.
+- **Outlook management & SharePoint archiving**: Automatic moving and categorising of emails into predefined Outlook folders; archiving of original and generated invoice documents via Microsoft Graph API.
+- **Monitoring & logging**: End‑to‑end real‑time monitoring with Kibana, including alerting and dashboard creation.
+- **Team coordination**: Managing the developer team incl. code reviews.
+
+**Tools & technologies**
+- Azure Functions: Serverless orchestration of automation workflows.
+- Python: Core logic for data extraction, classification and integration with automated CI/CD processes, packaging, and comprehensive unit and integration tests for quality assurance.
+- Microsoft Graph API: Access to Outlook mailboxes and SharePoint libraries.
+- GitHub: Version control, CI/CD pipelines and collaborative development.
+- Kibana: Monitoring, log analysis and performance dashboards.
+- Streamlit: For developing an interactive web application for visualization.
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "Project Management & Technical Lead"
+        dates = "04/2023 - 04/2024"
+        company = "Ryze"
+        details = """
+**Project management & technical lead**: Development and deployment of an AI-driven email bot to automate customer communication, AI-assisted processing of incoming emails and triggering of follow-up activities in existing SAP systems. Responsible for end-to-end project coordination and team management from idea to implementation.
+
+**Focus areas**:
+- **Development of ML models**: Design and training of specialized models for effective email classification, implemented via Azure Functions.
+- **API integrations**: Seamless connection to Microsoft Outlook 365 via Microsoft Graph API and to SAP systems for customer data checks.
+- **Process automation**: Automatic moving of emails based on classification and specific business rules, including complaint handling.
+- **DevOps and monitoring**: Implementation of CI/CD pipelines and use of Kibana for monitoring.
+- **Development of a Streamlit-based user interface**: Improved testability and visualization of process results.
+- **Team coaching**: Technical guidance for developers with regular code reviews and problem-solving sessions.
+
+**Tools & technologies**
+- Azure Functions: For serverless application architectures and ML model execution.
+- Python: Main programming language for the email bot and ML models.
+- Microsoft Graph API: For accessing and processing emails in Microsoft Outlook 365.
+- SAP API: For querying customer data and communicating with SAP systems.
+- GitHub: For version control, CI/CD pipelines and collaborative development.
+- Kibana: For real-time monitoring and system performance analysis.
+- Streamlit: For developing an interactive web application for system monitoring.
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "AI Workshop for Business Integration"
+        dates = "2023"
+        company = "Applications of AI in Business Context"
+        details = """
+**AI workshop**: Comprehensive presentation and live demonstration of innovative AI applications for business with a focus on practical implementation, theory and code examples.
+
+**Presentation content**
+- Comprehensive overview of AI fields and patterns (supervised/unsupervised/semi-supervised learning)
+- Deep dives into machine learning, deep learning and natural language processing
+- Detailed look at GPT models and their functionality (next token prediction)
+- Practical prompt engineering with examples for various use cases
+- Introduction to tools such as Hugging Face, Stable Diffusion, Midjourney and Auto-GPT
+
+**Practical workshop part**
+- Development of an intelligent Q&A bot with OpenAI GPT-3.5-Turbo
+- Live development of a web scraper for data acquisition
+- Extraction and vectorization of text embeddings with OpenAI models
+- Implementation of similarity search for context-based answers
+- Similarity analysis and visualization of results
+- Creation of an interactive Streamlit user interface for the Q&A bot
+
+**Technologies used**
+- OpenAI API (GPT-3.5-Turbo, Embedding-Ada-002)
+- Python with Pandas, NumPy and Streamlit
+- Vector embeddings and cosine similarity for semantic search
+- Web scraping with BeautifulSoup and Requests
+- Prompt engineering and AI integration into business processes
+- Integration via RESTful APIs
+
+The full presentation is available at [Pitch.com](https://pitch.com/public/bc7eaebb-5fb1-4e6f-bf84-ce9363c7abc0). The complete source code of the developed Q&A bot is documented in my [GitHub repository](https://github.com/boiman-solutions/workshop-q-a-scrap-bot).
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Quality Lead"
+        dates = "01/2017 - 05/2021"
+        company = "DB Vertrieb"
+        details = """
+**Test management, test coordination, test automation – agile (Kanban, Scrum, SAFe)**: Coordination as PO of a cross-team QA team including cross-team onboarding, support, consulting, training
+**Key responsibilities**
+- Agile quality assurance through the design of quality gates in the CI/CD pipeline
+- Design and implementation of functional and technical dashboards with Kibana, Graylog, Grafana, Instana & Elastic Search
+- Performance tests within CI/CD with Gatling / JMeter and analysis using Kibana, Graylog, Grafana and Instana
+- Documentation of quality metrics on the progress of measurable sprint quality
+- Design and setup of CI/CD pipelines for data tests
+- Functional and technical problem analysis
+- Consulting, design and implementation of solutions for quality-related issues
+- Setup of Junit, unit tests and integration tests, among others with Java Cucumber
+- Development of a hybrid app for presenting (reviewing) results on a web or mobile platform
+- Coordination of integration tests between the involved teams
+
+**Tools**
+- IntelliJ
+- Java
+- Cucumber / Cypress
+- J-Meter / Gatling
+- CI/CD / GitLab CI / Jenkins
+- Helm / Docker
+- JIRA / Confluence
+- Kibana / Grafana / Instana / Graylog
+- Behaviour Driven Development
+- Consumer Driven Contracts (Spring Cloud Contract)
+- Ionic (hybrid app)
+- Selenium
+        """
+
+        [[languages.de.params.jobs.list]]
+        position = "Load and Performance Testing / Test Automation / Test Management"
+        dates = "09/2015 - 01/2017"
+        company = "DB Systel"
+        details = """
+**Load and performance tests and analysis – test manager, test designer, analyst**: Development, execution and analysis of load and performance tests
+**Key responsibilities**
+- Requirements management
+- Status reports
+- Customer consulting
+- Documentation in the form of test concepts, analyses, management reporting and wiki documentation
+- Setup and execution of load and performance tests
+- Analysis of results & performance logs
+
+**Tools**
+- Visual Studio
+- Eclipse
+- JMeter
+- Git
+- JIRA / Confluence
+- Excel & Access VBS
+- Interfaces: HTTP, WS, REST, MQ, JMS
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "Senior iOS Developer"
+        dates = "04/2015 - 09/2015"
+        company = "Telekom"
+        details = """
+**Senior iOS Developer**: Further development of the rebuilt version of Deutsche Telekom's **Customer Center App**, extension with new functionalities for IFA.
+**Key responsibilities**
+- Swift
+- iOS 8
+- Requests & responses to backend
+- Error handling
+- iPad / iPhone
+- Scrum
+
+**Tools**
+- Xcode
+- Git
+- JIRA
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "QA, Test Management"
+        dates = "05/2009 - 03/2015"
+        company = "Siemens"
+        details = """
+**QA, test management, test automation, requirements engineering**: A total of 5 projects were supported as QA & test manager and successfully implemented
+**Projects**
+- SIPCA - Management system for employee annual targets and bonus calculation
+- STM - Application and travel expense recording (Frontend: Web / Backend: SAP)
+- GPM2 - Share bonus program for employees (Frontend: Web / Backend: JBoss)
+- PATAC
+- SOM - Management and overview of OrgUnits
+
+**Key responsibilities**
+- Creation of technical test concepts and test plans
+- Defect tracking
+- Management of CRs, communication between customers and developers
+- Creation, maintenance and scheduling of test automation
+- User acceptance tests
+- Training of new testers and test automation engineers
+- Support as test manager after project completion in regular operation
+- Setup of acceptance tests
+- Transfer of functional specification and detailed specification to Quality Center
+- Monitoring of implemented requirements against the detailed concept
+
+**Tools**
+- HP ALM
+- HP UFT
+- HP QC
+- Quick Test Pro
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "Load and Performance Tester"
+        dates = "03/2009 - 05/2009"
+        company = "ING-DIBA"
+        details = """
+**Load and performance tester**: The goal of the project is the design and development of LoadRunner scripts for load testing a bundle of approx. 20 J2EE applications in a banking portal
+**Key responsibilities**
+- Creation of test scripts in LoadRunner with the http protocol
+- Execution of load tests and analysis of results
+- Monitoring and reporting
+
+**Tools**
+- LoadRunner
+        """
+
+        [[languages.en.params.jobs.list]]
+        position = "Summary of Various Activities"
+        dates = "01/2006 - 12/2008"
+        company = "British Telecom, Mobiliar, DB-Systel, Sparkassen Informatik, Loyalty Partner, Telekom, Itelium, Deutsche Post, Postbank"
+        details = """
+**Load and performance tester / tester**: Various projects, predominantly load & performance tests
+**Key responsibilities**
+- Creation of test scripts in LoadRunner with the http protocol
+- Execution of load tests and analysis of results
+- Monitoring and reporting
+
+**Tools**
+- LoadRunner
+        """
+
+      [languages.de.params.projects]
+        enable = true
+        icon = "fa-archive"
+        title = "NEBENPROJEKTE"
+        intro = "**Weitere Projekte außerhalb des Kerngeschäfts**"
+
+        [[languages.de.params.projects.list]]
+        title = "wecation"
+        url = "https://www.wecation.de"
+        tagline = "wecation ist eine kollaborative Lösung zur Organisation gemeinsamer Erlebnisse: Plane, suche, stimme dich mit deinen Freunden oder Kollegen kollaborativ ab und genießt gemeinsam das Erlebnis!"
+
+        [[languages.de.params.projects.list]]
+        title = "QualityCluster"
+        url = "https://qualitycluster.de"
+        tagline = """
+QualityCluster ist ein Zusammenschluss von Quality Engineers, um gemeinsam bessere Lösungen im Bereich Software Qualitätssicherung zu entwickeln. 
+Unser Ziel ist es, mehr Qualität durch höheren Automatisierungsgrad zu verwirklichen. 
+"""
+
+        [[languages.de.params.projects.list]]
+        title = "KI-basierter Chatbot für Messe-Interaktion"
+        url = "#"
+        tagline = "Entwicklung eines interaktiven Chatbots unter Verwendung von RAG und OpenAI, um die Benutzerinteraktion auf einer Messe-Website zu optimieren."
+
+        [[languages.de.params.projects.list]]
+        title = "Automatisierte NLP-Analyse von PDF-Dokumenten"
+        url = "#"
+        tagline = "Einsatz von NLP-Technologien zur Effizienzsteigerung in der automatisierten Dokumentenanalyse."
+
+        [[languages.de.params.projects.list]]
+        title = "E-Mail-Klassifizierung und -Verarbeitungsprozess"
+        url = "#"
+        tagline = "Integration von Microsoft Graph API, SAP, Azure Functions, REST-API, OpenAI, ElasticSearch und Kibana zur Optimierung der E-Mail-Verarbeitung."
+
+        [[languages.de.params.projects.list]]
+        title   = "MCP - Model Context Protokoll"
+        url     = "#"
+        tagline = "Umsetzung verschiedener Tools zur Modell-Kontext-Orchestrierung."
+
+        [[languages.de.params.projects.list]]
+        title   = "AI-Automatisierungs-Functionsbausteine"
+        url     = "#"
+        tagline = "Aufbau von Functions-Bausteinen zur schnelleren Einführung von AI-Automatisierung."
+
+        [[languages.de.params.projects.list]]
+        title   = "AI-Beratung für Unternehmen"
+        url     = "#"
+        tagline = "Beratungen zum Einsatz von AI im Unternehmen."
+
+      [languages.en.params.projects]
+        enable = true
+        icon = "fa-archive"
+        title = "PROJECTS"
+        intro = "**Additional projects outside the core business**"
+
+        [[languages.en.params.projects.list]]
+        title = "wecation"
+        url = "https://www.wecation.de"
+        tagline = "wecation is a collaborative solution for organising shared experiences: plan, search, coordinate with friends or colleagues and enjoy the activity together!"
+
+        [[languages.en.params.projects.list]]
+        title = "QualityCluster"
+        url = "https://qualitycluster.de"
+        tagline = """
+QualityCluster is an alliance of quality engineers jointly developing better solutions in software quality assurance.  
+Our goal is to implement more quality through a higher degree of automation.  
+"""
+
+        [[languages.en.params.projects.list]]
+        title = "AI-Driven Chatbot for Trade-Fair Interaction"
+        url = "#"
+        tagline = "Development of an interactive chatbot using RAG and OpenAI to optimise user interaction on a trade-fair website."
+
+        [[languages.en.params.projects.list]]
+        title = "Automated NLP Analysis of PDF Documents"
+        url = "#"
+        tagline = "Using NLP technologies to boost efficiency in automated document analysis."
+
+        [[languages.en.params.projects.list]]
+        title = "Email Classification and Processing Workflow"
+        url = "#"
+        tagline = "Integration of Microsoft Graph API, SAP, Azure Functions, REST API, OpenAI, Elasticsearch and Kibana to optimise email processing."
+
+        [[languages.en.params.projects.list]]
+        title = "MCP – Model Context Protocol"
+        url = "#"
+        tagline = "Implementation of various tools for model-context orchestration."
+
+        [[languages.en.params.projects.list]]
+        title = "AI Automation Function Modules"
+        url = "#"
+        tagline = "Building function modules for faster rollout of AI automation."
+
+        [[languages.en.params.projects.list]]
+        title = "AI Consulting for Enterprises"
+        url = "#"
+        tagline = "Consultancy on the use of AI within companies."
+
+      [languages.de.params.skills]
+        enable = true
+        icon = "fa-rocket"
+        title = "Skills & Tools"
+
+        [[languages.de.params.skills.list]]
+        skill = "Python (Datenanalyse, ML/AI, Automatisierung)"
+        level = "98%"
+        
+        [[languages.de.params.skills.list]]
+        skill = "AI & Machine Learning"
+        level = "96%"
+
+        [[languages.de.params.skills.list]]
+        skill = "Software-Entwicklung, -Design, -Architektur"
+        level = "99%"
+
+        [[languages.de.params.skills.list]]
+        skill = "Jira & Confluence"
+        level = "98%"
+                
+        [[languages.de.params.skills.list]]
+        skill = "IntelliJ & VS Code"
+        level = "93%"
+
+        [[languages.de.params.skills.list]]
+        skill = "Playwright"
+        level = "97%"
+
+        [[languages.de.params.skills.list]]
+        skill = "Cucumber / Gauge / Taiko"
+        level = "99%"
+
+        [[languages.de.params.skills.list]]
+        skill = "CDC - Spring Contract & Pact.io"
+        level = "70%"
+
+        [[languages.de.params.skills.list]]
+        skill = "CI/CD-Workflows - Gitlab & Github & Jenkins"
+        level = "90%"
+
+        [[languages.de.params.skills.list]]
+        skill = "Kubernetes - Helm & Terraform & ArgoCD"
+        level = "80%"
+
+        [[languages.de.params.skills.list]]
+        skill = "REST & Postman"
+        level = "95%"
+
+        [[languages.de.params.skills.list]]
+        skill = "Last und Performance Testing mit J-Meter, Gatling"
+        level = "90%"
+
+        [[languages.de.params.skills.list]]
+        skill = "AWS & Google & Azure"
+        level = "80%"
+
+        [[languages.de.params.skills.list]]
+        skill = """
+        Dashboards & Analyse - \n
+        Kibana(+ES) & Greylog &  \n
+        Grafana & Instana 
+        """
+        level = "90%"
+
+        [[languages.de.params.skills.list]]
+        skill = "MobileDev - X-Code & Flutter & Swift"
+        level = "90%"
+
+      [languages.en.params.skills]
+        enable = true
+        icon = "fa-rocket"
+        title = "SKILLS & TOOLS"
+
+        [[languages.en.params.skills.list]]
+        skill = "Python (Data Analysis, ML/AI, Automation)"
+        level = "98%"
+        
+        [[languages.en.params.skills.list]]
+        skill = "AI & Machine Learning"
+        level = "96%"
+        
+        [[languages.en.params.skills.list]]
+        skill = "Software Development, Design, Architecture"
+        level = "99%"
+
+        [[languages.en.params.skills.list]]
+        skill = "JIRA & Confluence"
+        level = "98%"
+
+        [[languages.en.params.skills.list]]
+        skill = "IntelliJ & VS Code"
+        level = "93%"
+
+        [[languages.en.params.skills.list]]
+        skill = "Playwright"
+        level = "97%"
+
+        [[languages.en.params.skills.list]]
+        skill = "Cucumber / Gauge / Taiko"
+        level = "99%"
+
+        [[languages.en.params.skills.list]]
+        skill = "CDC – Spring Contract & Pact.io"
+        level = "70%"
+
+        [[languages.en.params.skills.list]]
+        skill = "CI/CD Workflows – GitLab, GitHub & Jenkins"
+        level = "90%"
+
+        [[languages.en.params.skills.list]]
+        skill = "Kubernetes – Helm, Terraform & ArgoCD"
+        level = "80%"
+
+        [[languages.en.params.skills.list]]
+        skill = "REST & Postman"
+        level = "95%"
+
+        [[languages.en.params.skills.list]]
+        skill = "Load & Performance Testing with JMeter, Gatling"
+        level = "90%"
+
+        [[languages.en.params.skills.list]]
+        skill = "AWS, Google Cloud & Azure"
+        level = "80%"
+
+        [[languages.en.params.skills.list]]
+        skill = """
+Dashboards & Analytics –  
+Kibana (+ES) & Graylog &  
+Grafana & Instana
+        """
+        level = "90%"
+
+        [[languages.en.params.skills.list]]
+        skill = "Mobile Dev – Xcode, Flutter & Swift"
+        level = "90%"
+
+      [languages.de.params.footer]
+        copyright = "Michael.Boiman"

--- a/config.sample.custom.toml
+++ b/config.sample.custom.toml
@@ -1,5 +1,7 @@
 [languages.de.params.profile]
+name = "Max Mustermann"
 tagline = "Individuell angepasstes Profil"
 
 [languages.en.params.profile]
+name = "John Doe"
 tagline = "Customized profile for the request"

--- a/config.sample.custom.toml
+++ b/config.sample.custom.toml
@@ -1,6 +1,16 @@
+# Example overrides for a custom CV
+
+defaultContentLanguage = "de"
+
 [languages.de.params.profile]
 name = "Max Mustermann"
 tagline = "Individuell angepasstes Profil"
+
+[languages.de.params.summary]
+summary = "Kurzprofil für eine bestimmte Bewerbung."
+
+[languages.de.params.contact]
+enable = false
 
 [languages.en.params.profile]
 name = "John Doe"

--- a/config.sample.custom.toml
+++ b/config.sample.custom.toml
@@ -1,0 +1,5 @@
+[languages.de.params.profile]
+tagline = "Individuell angepasstes Profil"
+
+[languages.en.params.profile]
+tagline = "Customized profile for the request"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1101 @@
+{
+  "name": "cv-generator",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cv-generator",
+      "version": "1.0.0",
+      "dependencies": {
+        "puppeteer": "^24.10.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.10.5",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.5.tgz",
+      "integrity": "sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.2",
+        "tar-fs": "^3.0.8",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-events": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/bare-fs": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.5.tgz",
+      "integrity": "sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-5.1.0.tgz",
+      "integrity": "sha512-9MSRhWRVoRPDG0TgzkHrshFSJJNZzfY5UFqUMuksg7zL1yoZIZ3jLB0YAgHclbiAxPI86pBnwDX1tbzoiV8aFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1452169",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1452169.tgz",
+      "integrity": "sha512-FOFDVMGrAUNp0dDKsAU1TorWJUx2JOU1k9xdgBKKJF3IBh/Uhl2yswG5r3TEAOrCiGY2QRp1e6LVDQrCsTKO4g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-uri": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
+      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/puppeteer": {
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.10.0.tgz",
+      "integrity": "sha512-Oua9VkGpj0S2psYu5e6mCer6W9AU9POEQh22wRgSXnLXASGH+MwLUVWgLCLeP9QPHHcJ7tySUlg4Sa9OJmaLpw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.10.5",
+        "chromium-bidi": "5.1.0",
+        "cosmiconfig": "^9.0.0",
+        "devtools-protocol": "0.0.1452169",
+        "puppeteer-core": "24.10.0",
+        "typed-query-selector": "^2.12.0"
+      },
+      "bin": {
+        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.10.0.tgz",
+      "integrity": "sha512-xX0QJRc8t19iAwRDsAOR38Q/Zx/W6WVzJCEhKCAwp2XMsaWqfNtQ+rBfQW9PlF+Op24d7c8Zlgq9YNmbnA7hdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.10.5",
+        "chromium-bidi": "5.1.0",
+        "debug": "^4.4.1",
+        "devtools-protocol": "0.0.1452169",
+        "typed-query-selector": "^2.12.0",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.4.tgz",
+      "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/streamx": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.56",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.56.tgz",
+      "integrity": "sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cv-generator",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "puppeteer": "^24.10.0"
+  }
+}

--- a/scripts/generate_cv.sh
+++ b/scripts/generate_cv.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+BASE_CONFIG="config.toml"
+CUSTOM_CONFIG="$1"
+OUTPUT_PDF="${2:-cv_custom.pdf}"
+BUILD_DIR=$(mktemp -d)
+
+if [ -z "$CUSTOM_CONFIG" ]; then
+  echo "Usage: $0 <custom_config.toml> [output.pdf]"
+  exit 1
+fi
+
+# Build site with base and custom configuration
+hugo --config "$BASE_CONFIG,$CUSTOM_CONFIG" -d "$BUILD_DIR"
+
+# Convert generated HTML to PDF
+wkhtmltopdf --enable-local-file-access --print-media-type "$BUILD_DIR/index.html" "$OUTPUT_PDF"
+
+# Clean up
+rm -rf "$BUILD_DIR"
+
+echo "PDF generated at $OUTPUT_PDF"

--- a/scripts/generate_cv.sh
+++ b/scripts/generate_cv.sh
@@ -14,8 +14,11 @@ fi
 # Build site with base and custom configuration
 hugo --config "$BASE_CONFIG,$CUSTOM_CONFIG" -d "$BUILD_DIR"
 
-# Convert generated HTML to PDF
-wkhtmltopdf --enable-local-file-access --print-media-type "$BUILD_DIR/index.html" "$OUTPUT_PDF"
+# Convert generated HTML to PDF using Puppeteer
+if [ ! -d node_modules ]; then
+  npm ci --silent
+fi
+node scripts/html_to_pdf.js "$BUILD_DIR/index.html" "$OUTPUT_PDF"
 
 # Clean up
 rm -rf "$BUILD_DIR"

--- a/scripts/generate_cv.sh
+++ b/scripts/generate_cv.sh
@@ -18,7 +18,11 @@ hugo --config "$BASE_CONFIG,$CUSTOM_CONFIG" -d "$BUILD_DIR"
 if [ ! -d node_modules ]; then
   npm ci --silent
 fi
-node scripts/html_to_pdf.js "$BUILD_DIR/index.html" "$OUTPUT_PDF"
+# Determine default language from merged configuration
+DEFAULT_LANG=$(grep -h "^defaultContentLanguage[[:space:]]*=" "$BASE_CONFIG" "$CUSTOM_CONFIG" | tail -n1 | cut -d'"' -f2)
+MAIN_PAGE="$BUILD_DIR/$DEFAULT_LANG/index.html"
+[ -f "$MAIN_PAGE" ] || MAIN_PAGE="$BUILD_DIR/index.html"
+node scripts/html_to_pdf.js "$MAIN_PAGE" "$OUTPUT_PDF"
 
 # Clean up
 rm -rf "$BUILD_DIR"

--- a/scripts/generate_cv.sh
+++ b/scripts/generate_cv.sh
@@ -4,6 +4,10 @@ set -e
 BASE_CONFIG="config.toml"
 CUSTOM_CONFIG="$1"
 OUTPUT_PDF="${2:-cv_custom.pdf}"
+STANDALONE=0
+if [ "$3" = "--standalone" ]; then
+  STANDALONE=1
+fi
 BUILD_DIR=$(mktemp -d)
 
 if [ -z "$CUSTOM_CONFIG" ]; then
@@ -11,8 +15,12 @@ if [ -z "$CUSTOM_CONFIG" ]; then
   exit 1
 fi
 
-# Build site with base and custom configuration
-hugo --config "$BASE_CONFIG,$CUSTOM_CONFIG" -d "$BUILD_DIR"
+# Build site with base and custom configuration or standalone
+if [ "$STANDALONE" -eq 1 ]; then
+  hugo --config "$CUSTOM_CONFIG" -d "$BUILD_DIR"
+else
+  hugo --config "$BASE_CONFIG,$CUSTOM_CONFIG" -d "$BUILD_DIR"
+fi
 
 # Convert generated HTML to PDF using Puppeteer
 if [ ! -d node_modules ]; then

--- a/scripts/html_to_pdf.js
+++ b/scripts/html_to_pdf.js
@@ -1,0 +1,17 @@
+const puppeteer = require('puppeteer');
+const path = require('path');
+
+(async () => {
+  const [,, inputHtml, outputPdf] = process.argv;
+  if (!inputHtml || !outputPdf) {
+    console.error('Usage: node html_to_pdf.js <input.html> <output.pdf>');
+    process.exit(1);
+  }
+
+  const browser = await puppeteer.launch({args: ['--no-sandbox', '--disable-setuid-sandbox']});
+  const page = await browser.newPage();
+  const fileUrl = 'file://' + path.resolve(inputHtml);
+  await page.goto(fileUrl, {waitUntil: 'networkidle0'});
+  await page.pdf({path: outputPdf, format: 'A4', printBackground: true});
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- document CV build instructions
- provide sample override config
- add `generate_cv.sh` script to build and export PDF using a custom TOML

## Testing
- `hugo --minify`
- `./scripts/generate_cv.sh config.sample.custom.toml test.pdf`

------
https://chatgpt.com/codex/tasks/task_e_68443e3fa05c83249989cc4add993eb5