### PR TITLE
fix: respect OS prefers-color-scheme for theme on first visit

### DIFF
--- a/src/components/DarkModeToggle.astro
+++ b/src/components/DarkModeToggle.astro
@@ -35,6 +35,13 @@
     updateIcons();
   });
 
+  // Follow the OS setting live — until the user makes an explicit choice
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+    if (localStorage.getItem('theme')) return;
+    document.documentElement.classList.toggle('dark', e.matches);
+    updateIcons();
+  });
+
   updateIcons();
 </script>
 

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -29,12 +29,16 @@ const otherPath = currentPath.replace(`/${lang}/`, `/${otherLang}/`);
   <meta property="og:image" content="https://mboiman.github.io/images/profile_.jpg" />
   <meta property="og:url" content={`https://mboiman.github.io${currentPath}`} />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="theme-color" content="#f8fbff" />
+  <meta name="theme-color" content="#f8fbff" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)" />
   <script is:inline>
     (() => {
       try {
         const saved = localStorage.getItem('theme');
-        if (saved === 'dark') document.documentElement.classList.add('dark');
+        const isDark = saved
+          ? saved === 'dark'
+          : window.matchMedia('(prefers-color-scheme: dark)').matches;
+        document.documentElement.classList.toggle('dark', isDark);
       } catch {}
     })();
   </script>


### PR DESCRIPTION
Das Theme wurde beim Laden nur aus `localStorage` gesetzt — ein Erstbesucher bekam immer Light, unabhängig von seiner OS-Hell/Dunkel-Einstellung.

- `BaseLayout.astro`: Inline-Script fällt auf `prefers-color-scheme` zurück, wenn keine explizite Wahl gespeichert ist (vor dem Paint → kein Flash)
- `BaseLayout.astro`: `theme-color`-Meta media-scoped für Light/Dark (mobile Browser-Chrome)
- `DarkModeToggle.astro`: folgt OS-Wechseln live, bis der User per Toggle explizit wählt

`npm run build` grün; Fix im generierten `dist/de|en/index.html` verifiziert.

Nachzügler zu #42 (war beim Merge von #42 noch nicht gepusht).