### PR TITLE
feat(agent-widget): chat open by default on the CV page

### DIFF
--- a/src/components/AgentWidget.astro
+++ b/src/components/AgentWidget.astro
@@ -1851,7 +1851,18 @@ const widgetStrings = {
       if (resizeHandle) resizeHandle.setAttribute('title', t.resize || 'Drag to resize');
     }
 
-    function openPanel() {
+    const OPEN_KEY = 'bridgeAgentWidgetOpen';
+    // The chat is open by default on the CV page. First visit: open on desktop, but
+    // stay collapsed on a phone (an open panel would cover the whole CV). After that,
+    // always honor the visitor's last explicit choice.
+    function shouldAutoOpen(): boolean {
+      let s: string | null = null;
+      try { s = localStorage.getItem(OPEN_KEY); } catch {}
+      if (s === 'closed') return false;   // visitor closed it → keep it closed
+      if (s === 'open') return true;       // visitor opened it → keep it open
+      return !isMobile();                  // first visit: desktop open, phone collapsed
+    }
+    function openPanel(opts: { focus?: boolean } = {}) {
       panel.hidden = false;
       panelOpen = true;
       applySizeState(sizeState); // restore persisted size/mode
@@ -1860,7 +1871,10 @@ const widgetStrings = {
       launcher.setAttribute('aria-expanded', 'true');
       if (!greeted) { addBubble('agent', t.greeting); greeted = true; }
       if (!cardFetched) { cardFetched = true; loadAgentCard(); }
-      setTimeout(() => input.focus(), 50);
+      try { localStorage.setItem(OPEN_KEY, 'open'); } catch {}
+      // Auto-open (page load) must NOT steal focus or scroll the page to the widget;
+      // manual open focuses the input so the visitor can type right away.
+      if (opts.focus !== false) setTimeout(() => input.focus({ preventScroll: true }), 50);
     }
     function openPanelWithPrompt(text: string) {
       openPanel();
@@ -1871,6 +1885,7 @@ const widgetStrings = {
     function closePanel() {
       panel.hidden = true;
       panelOpen = false;
+      try { localStorage.setItem(OPEN_KEY, 'closed'); } catch {}   // visitor's choice sticks
       if (cardShown) closeCard();   // next open starts on the chat view
       launcher.classList.remove('aw-hidden');
       launcherLabel?.classList.remove('aw-hidden');
@@ -1882,9 +1897,9 @@ const widgetStrings = {
     if (launcherLabel) {
       launcherLabel.querySelector('.aw-label-text')!.textContent = t.launcherText || t.launcherLabel;
       launcherLabel.setAttribute('title', t.launcherLabel);
-      launcherLabel.addEventListener('click', openPanel);
+      launcherLabel.addEventListener('click', () => openPanel());
     }
-    launcher.addEventListener('click', openPanel);
+    launcher.addEventListener('click', () => openPanel());
     window.addEventListener('bridge-agent:prompt', (event) => {
       const custom = event as CustomEvent<{ text?: string }>;
       openPanelWithPrompt(custom.detail?.text || '');
@@ -1901,5 +1916,9 @@ const widgetStrings = {
       input.value = '';
       send(v);
     });
+
+    // Open by default (desktop, first visit; always honor the saved choice) —
+    // focus:false so a page load never scrolls to or steals focus for the widget.
+    if (shouldAutoOpen()) openPanel({ focus: false });
   }
 </script>


### PR DESCRIPTION
Feedback: der Chat soll auf der CV-Seite schon offen sein, nicht hinter dem Launcher.

- **Default-offen** beim ersten Besuch — aber nur auf Desktop (auf dem Handy würde ein offenes Panel die ganze CV verdecken → bleibt dort eingeklappt).
- **Wahl des Besuchers bleibt erhalten** (`localStorage`): einmal geschlossen → bleibt zu; wieder geöffnet → bleibt offen.
- **Auto-Open stiehlt keinen Fokus und scrollt die Seite nicht** zum Widget (`focus:false` + `preventScroll`); manuelles Öffnen fokussiert das Eingabefeld wie bisher.

`npm run build` grün, Logik im Bundle verifiziert.