### PR TITLE
Agent springt zu Sektionen, ruhigeres Streaming, Header-Link entschlackt

### DIFF
--- a/src/components/AgentWidget.astro
+++ b/src/components/AgentWidget.astro
@@ -1272,6 +1272,14 @@ const widgetStrings = {
 
     // --- DOM helpers ----------------------------------------------------------
     function scrollToBottom() { messagesEl.scrollTop = messagesEl.scrollHeight; }
+    // Like scrollToBottom but only follows the growing answer while the reader is
+    // already at the bottom — if they scrolled up to re-read, we don't yank them
+    // back down. Used during the paced live reveal so long answers glide rather
+    // than snap.
+    function stickToBottom() {
+      const slack = messagesEl.scrollHeight - messagesEl.scrollTop - messagesEl.clientHeight;
+      if (slack < 120) messagesEl.scrollTop = messagesEl.scrollHeight;
+    }
 
     // Speech-bubble glyph (same as the launcher) — the agent's identity chip.
     const AGENT_AVATAR_SVG =
@@ -1601,9 +1609,36 @@ const widgetStrings = {
         if (!bubble) bubble = addBubble('agent', '');
         return bubble;
       }
+      // Paced reveal: the server may deliver the answer in big chunks (or one
+      // 'completed' frame). Dumping each chunk makes the panel lurch downward, so
+      // instead we hold the newest full text as a target and reveal it a few chars
+      // per animation frame — even a one-shot answer then reads like a stream.
+      // Catch up faster when far behind so we never lag a fast sender; honour
+      // prefers-reduced-motion by showing everything at once.
+      let liveTarget = '';
+      let liveShown = 0;
+      let paceRAF = 0;
+      const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      function paintLive() {
+        ensureBubble().innerHTML = safeMarkdown(liveTarget.slice(0, liveShown));
+        stickToBottom();
+      }
+      function pump() {
+        paceRAF = 0;
+        if (liveShown >= liveTarget.length) return;
+        const backlog = liveTarget.length - liveShown;
+        liveShown = Math.min(liveTarget.length, liveShown + (backlog > 400 ? 60 : 18));
+        paintLive();
+        if (liveShown < liveTarget.length) paceRAF = requestAnimationFrame(pump);
+      }
       function renderLive(text: string) {
-        ensureBubble().innerHTML = safeMarkdown(text);
-        scrollToBottom();
+        liveTarget = text;
+        if (liveShown > liveTarget.length) liveShown = 0;   // replaced/shrank → restart
+        if (reduceMotion) { liveShown = liveTarget.length; paintLive(); return; }
+        if (!paceRAF) paceRAF = requestAnimationFrame(pump);
+      }
+      function finishLive() {
+        if (paceRAF) { cancelAnimationFrame(paceRAF); paceRAF = 0; }
       }
 
       try {
@@ -1660,6 +1695,7 @@ const widgetStrings = {
           }
         }
       } finally {
+        finishLive();
         indicator.el.remove();
       }
 
@@ -1748,8 +1784,11 @@ const widgetStrings = {
       // On mobile the panel is fullscreen and covers the CV → collapse it first.
       if (isMobile() && panelOpen) closePanel();
       const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      // A section anchor (a whole group) aligns to its top so the heading leads;
+      // a single entry centres in view.
+      const block = (target.hasAttribute('data-cv-group') ? 'start' : 'center') as ScrollLogicalPosition;
       const run = () => {
-        target.scrollIntoView({ behavior: reduce ? 'auto' : 'smooth', block: 'center' });
+        target.scrollIntoView({ behavior: reduce ? 'auto' : 'smooth', block });
         target.classList.add('bridge-flash');
         flashEl = target;
         const label = (target.querySelector('h2, h3, h4') as HTMLElement | null)?.textContent?.trim();
@@ -1799,15 +1838,32 @@ const widgetStrings = {
 
     /** Advisory context string handed to the agent each turn (localized). */
     function buildRuntimeContext(): string {
-      const anchors = Array.from(document.querySelectorAll<HTMLElement>('[data-cv-anchor]'))
-        .map((el) => el.getAttribute('data-cv-anchor') || '')
-        .filter((a) => ANCHOR_RE.test(a));
-      const uniq = Array.from(new Set(anchors));
+      const all = Array.from(document.querySelectorAll<HTMLElement>('[data-cv-anchor]'))
+        .filter((el) => ANCHOR_RE.test(el.getAttribute('data-cv-anchor') || ''));
+      // A section anchor carries data-cv-group (its human label) and stands for a
+      // whole group of entries — usable for category/overview questions. Plain
+      // entry anchors point at a single item. We tell the agent both, separately,
+      // so it can pick a section for "which talks?" and an entry for a specific one.
+      const sectionSlugs = new Set(
+        all.filter((el) => el.hasAttribute('data-cv-group'))
+           .map((el) => el.getAttribute('data-cv-anchor') || ''),
+      );
+      const sections = all
+        .filter((el) => el.hasAttribute('data-cv-group'))
+        .map((el) => ({
+          a: el.getAttribute('data-cv-anchor') || '',
+          label: (el.getAttribute('data-cv-group') || '').trim().replace(/\s+/g, ' ').slice(0, 60),
+        }));
+      const entries = Array.from(new Set(
+        all.map((el) => el.getAttribute('data-cv-anchor') || '')
+           .filter((a) => !sectionSlugs.has(a)),
+      ));
       const visEl = currentVisibleAnchor();
       const visAnchor = visEl ? visEl.getAttribute('data-cv-anchor') : '';
       const visLabel = visEl
-        ? ((visEl.querySelector('h2,h3,h4') as HTMLElement | null)?.textContent || '')
-            .trim().replace(/\s+/g, ' ').slice(0, 80)
+        ? (visEl.getAttribute('data-cv-group')
+            || (visEl.querySelector('h2,h3,h4') as HTMLElement | null)?.textContent
+            || '').trim().replace(/\s+/g, ' ').slice(0, 80)
         : '';
       const path = location.pathname;
       if (lang === 'en') {
@@ -1815,18 +1871,20 @@ const widgetStrings = {
           ? `Currently in the visitor's view: section “${visLabel}” (anchor ${visAnchor}).`
           : `No specific section is in the visitor's view right now.`;
         return [
-          `You are embedded on Michael Boiman's CV page (path ${path}, UI language ${lang}). You can guide this page: scrolling to and briefly highlighting one section.`,
+          `You are embedded on Michael Boiman's CV page (path ${path}, UI language ${lang}). You can guide this page: scrolling to and briefly highlighting one section via ⟦ui:highlight <anchor>⟧.`,
           vis,
-          uniq.length ? `Sections highlightable on THIS page — authoritative anchor list for ⟦ui:highlight <anchor>⟧: ${uniq.join(', ')}.` : '',
+          sections.length ? `Section anchors (each spans a whole group — use one for a category/overview question, e.g. "which talks?"): ${sections.map((s) => `${s.a} (${s.label})`).join(', ')}.` : '',
+          entries.length ? `Single-entry anchors (use one when the answer points at a specific entry): ${entries.join(', ')}.` : '',
         ].filter(Boolean).join('\n');
       }
       const vis = visAnchor
         ? `Aktuell im Blickfeld des Besuchers: Abschnitt „${visLabel}“ (Anker ${visAnchor}).`
         : `Aktuell ist kein bestimmter Abschnitt im Blickfeld des Besuchers.`;
       return [
-        `Sie sind auf Michael Boimans CV-Seite eingebettet (Pfad ${path}, Oberflächensprache ${lang}). Sie können diese Seite führen: zu einem Abschnitt scrollen und ihn kurz hervorheben.`,
+        `Sie sind auf Michael Boimans CV-Seite eingebettet (Pfad ${path}, Oberflächensprache ${lang}). Sie können diese Seite führen: zu einem Abschnitt scrollen und ihn kurz hervorheben via ⟦ui:highlight <anchor>⟧.`,
         vis,
-        uniq.length ? `Auf DIESER Seite hervorhebbare Abschnitte — autoritative Anker-Liste für ⟦ui:highlight <anchor>⟧: ${uniq.join(', ')}.` : '',
+        sections.length ? `Abschnitts-Anker (umfassen je eine ganze Gruppe — einer davon für Kategorie-/Übersichtsfragen, z. B. „welche Vorträge?"): ${sections.map((s) => `${s.a} (${s.label})`).join(', ')}.` : '',
+        entries.length ? `Einzel-Anker (einer davon, wenn die Antwort auf einen bestimmten Eintrag zeigt): ${entries.join(', ')}.` : '',
       ].filter(Boolean).join('\n');
     }
 

--- a/src/components/CVPage.astro
+++ b/src/components/CVPage.astro
@@ -144,11 +144,7 @@ function truncateDetails(details: string): string {
   <header class="cv-hero relative overflow-hidden px-6 sm:px-8">
     <div class="relative max-w-6xl mx-auto pt-6 pb-14 lg:pb-16">
       <!-- Top bar -->
-      <div class="flex items-center justify-between mb-8 text-sm">
-        <a href={`/${lang}/story/`} class="group opacity-70 hover:opacity-100 transition-all cursor-pointer flex items-center gap-2" style="color: var(--accent)">
-          {t.experienceTheStory}
-          <svg class="w-4 h-4 group-hover:translate-x-1 transition-transform" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M14 5l7 7m0 0l-7 7m7-7H3" /></svg>
-        </a>
+      <div class="flex items-center justify-end mb-8 text-sm">
         <div class="flex items-center gap-3">
           <a href="/de/" class={lang === 'de' ? 'cv-lang-link is-active' : 'cv-lang-link'}>DE</a>
           <span class="opacity-20">|</span>
@@ -292,7 +288,7 @@ function truncateDetails(details: string): string {
 
         <!-- PROJEKTE VOR ERFAHRUNG -->
         {projects.enable && (
-          <section>
+          <section id="section-projects" data-cv-anchor="projects" data-cv-group={projects.title}>
             <h2 class="cv-section-title">{projects.title}</h2>
             <p class="text-sm mb-6" style="color: var(--text-secondary)" set:html={formatMarkdown(projects.intro)} />
 
@@ -356,7 +352,7 @@ function truncateDetails(details: string): string {
 
         <!-- Berufserfahrung -->
         {experiences.enable && (
-          <section>
+          <section id="section-experience" data-cv-anchor="experience" data-cv-group={experiences.title}>
             <h2 class="cv-section-title">{experiences.title}</h2>
             <div class="cv-timeline space-y-6 relative ml-3 pl-7">
               {jobs.map((exp, i) => (
@@ -382,7 +378,7 @@ function truncateDetails(details: string): string {
 
         <!-- Vorträge & Workshops -->
         {talks.length > 0 && (
-          <section>
+          <section id="section-talks" data-cv-anchor="talks" data-cv-group={t.talksTitle}>
             <h2 class="cv-section-title">{t.talksTitle}</h2>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
               {talks.map(talk => (


### PR DESCRIPTION
## Was

Adressiert drei Punkte aus dem Live-Test:

1. **„Welche Vorträge hat Michael gehalten?" sprang nicht.** Kategorie-/Übersichtsfragen zeigen auf eine ganze Gruppe, nicht auf einen einzelnen Eintrag — die UI-Direktiv-Regel erlaubte aber nur Einzel-Einträge. Jetzt tragen die drei Abschnitte (Berufserfahrung, Vorträge & Workshops, Projekte) **Sektions-Anker** (`experience`/`talks`/`projects`) mit Gruppenlabel. Der Runtime-Context listet Sektions- und Einzel-Anker getrennt; der Agent wählt für eine Kategorie-Frage den Sektions-Anker → die Seite scrollt zur Gruppe und umrahmt sie ganz (oben ausgerichtet).
2. **„Experience the Story →" im Header war redundant** (es gibt denselben Link als CTA im Hero + im Footer) → der Header-Link ist entfernt.
3. **Langer Antworttext sprang ruckartig runter** → getakteter Reveal (requestAnimationFrame) + sanftes Am-Boden-Kleben: lange Antworten lesen sich wie ein Stream. Respektiert `prefers-reduced-motion`.

## Test

`npm run build` grün; lokaler Smoke-Test: keine Konsolen-Fehler, Sektions-Highlight scrollt + rahmt die Gruppe, Header zeigt nur noch DE/EN + Dark-Toggle.