### PR TITLE
Fix: Dark-Mode-Schatten des Agent-Widgets griffen nie (ungültiges :global())

### DIFF
--- a/src/components/AgentWidget.astro
+++ b/src/components/AgentWidget.astro
@@ -192,8 +192,8 @@ const widgetStrings = {
   }
 
   /* darker overlay alpha in dark mode (DESIGN.md: soften/strengthen per theme) */
-  :global(html.dark) #agent-widget-root,
-  :global(.dark) #agent-widget-root {
+  html.dark #agent-widget-root,
+  .dark #agent-widget-root {
     --aw-elev-panel: 0 16px 48px -8px rgba(0,0,0,0.55), 0 4px 12px -4px rgba(0,0,0,0.35);
     --aw-elev-launcher: 0 8px 24px -6px rgba(0,0,0,0.6), 0 2px 6px -2px rgba(0,0,0,0.4);
   }


### PR DESCRIPTION
Einzeiler-Nachzügler aus dem Astro-7-Upgrade (dort als Nebenfund dokumentiert, bewusst nicht in den Dependency-PR gemischt):

Der `<style>`-Block in `AgentWidget.astro` ist bereits `is:global` — der `:global()`-Wrapper um `html.dark`/`.dark` war dadurch ungültiges CSS, und die dunkleren Panel-/Launcher-Schatten für den Dark Mode wurden seit jeher vom Minifier verworfen (Astro 7/lightningcss warnt jetzt sichtbar davor, Astro 6 schluckte es stumm).

**Fix:** `:global()`-Wrapper entfernt → `html.dark #agent-widget-root, .dark #agent-widget-root`.

**Verifiziert:** Build grün ohne die Warnung; die Regel `html.dark #agent-widget-root` ist jetzt im gebauten CSS-Output enthalten (vorher nicht vorhanden).