### PR TITLE
fix(agent): derive the fact chips from the live agent-card

### DIFF
--- a/config.cv.toml
+++ b/config.cv.toml
@@ -93,7 +93,7 @@ defaultContentLanguageInSubdir = true
           "Wann hat Michael nächste Woche Zeit für ein Gespräch?",
           "Welche Erfahrung hat Michael mit KI-Agenten?"
         ]
-        facts = ["protocolVersion: 0.3", "transport: JSONRPC", "streaming: true", "skills: 4"]
+        facts = ["protocolVersion: 0.3", "transport: JSONRPC", "streaming: true", "skills: 5"]
 
       [languages.de.params.profile]
         name = "Michael Boiman"
@@ -727,7 +727,7 @@ Die vollständige Präsentation ist unter [Pitch.com](https://pitch.com/public/b
           "When is Michael available next week?",
           "What is Michael's experience with AI agents?"
         ]
-        facts = ["protocolVersion: 0.3", "transport: JSONRPC", "streaming: true", "skills: 4"]
+        facts = ["protocolVersion: 0.3", "transport: JSONRPC", "streaming: true", "skills: 5"]
 
       [languages.en.params.profile]
         name = "Michael Boiman"

--- a/src/components/AgentWidget.astro
+++ b/src/components/AgentWidget.astro
@@ -1456,6 +1456,45 @@ const widgetStrings = {
       return cardInflight;
     }
 
+    // --- Fact chips on the host page (progressive enhancement) ----------------
+    // Derive the "protocolVersion / transport / streaming / skills" chips from the card
+    // instead of hand-maintaining them in config. Returns null when the card can't
+    // answer, so the caller leaves the server-rendered fallback alone.
+    function factsFromCard(card: any): string[] | null {
+      if (!card || typeof card !== 'object') return null;
+      // Read BOTH A2A dialects. v1.0 moved version + binding onto supportedInterfaces[]
+      // and dropped the top-level pair; 0.3 has only the top level. Reading a single
+      // location is precisely the bug that cut this agent's own BKS consult off for
+      // five days — don't repeat it one layer up.
+      const iface = Array.isArray(card.supportedInterfaces)
+        ? card.supportedInterfaces.find((i: any) => i && typeof i === 'object')
+        : null;
+      const protocol = String(iface?.protocolVersion ?? card.protocolVersion ?? '').trim();
+      const transport = String(iface?.protocolBinding ?? card.preferredTransport ?? '').trim();
+      const streaming = card.capabilities?.streaming;
+      const skills = Array.isArray(card.skills) ? card.skills.length : null;
+
+      const facts: string[] = [];
+      if (protocol) facts.push(`protocolVersion: ${protocol}`);
+      if (transport) facts.push(`transport: ${transport}`);
+      if (typeof streaming === 'boolean') facts.push(`streaming: ${streaming}`);
+      if (skills !== null) facts.push(`skills: ${skills}`);
+      return facts.length ? facts : null;
+    }
+
+    function renderAgentFacts(card: any): void {
+      const host = document.querySelector('[data-agent-facts]');
+      if (!host) return;                       // host page has no chips — nothing to do
+      const facts = factsFromCard(card);
+      if (!facts) return;                      // unreachable/unusable card → keep fallback
+      host.replaceChildren(...facts.map((fact) => {
+        const el = document.createElement('span');
+        el.className = 'cv-agent-fact rounded-full px-2.5 py-1 text-[11px]';
+        el.textContent = fact;                 // textContent, never innerHTML — card data is remote
+        return el;
+      }));
+    }
+
     // =========================================================================
     // AGENT-CARD VIEW — renders the live A2A card inside the panel. Every value is
     // injected via textContent (never innerHTML), so even a compromised/injected
@@ -2253,5 +2292,14 @@ const widgetStrings = {
     // focus:false so a page load never scrolls to or steals focus for the widget;
     // persist:false so an auto-open is never stored as the visitor's choice.
     if (shouldAutoOpen()) openPanel({ focus: false, persist: false });
+
+    // The page's fact chips describe the LIVE agent, so read them off the live card
+    // rather than trusting the hand-written strings the server rendered: those drifted
+    // unnoticed (protocolVersion pinned at 0.3 long after the agent moved on, skills
+    // stuck at 4 against a card advertising 5). Progressive enhancement — on any
+    // failure the server-rendered fallback simply stays. loadAgentCard() de-dupes and
+    // caches, so this is at most ONE extra GET of static JSON, and zero when auto-open
+    // already fetched it.
+    loadAgentCard().then(renderAgentFacts);
   }
 </script>

--- a/src/components/CVPage.astro
+++ b/src/components/CVPage.astro
@@ -34,7 +34,7 @@ const agentProof = agent_proof ?? {
     lang === 'de' ? 'Wann hat Michael nächste Woche Zeit für ein Gespräch?' : 'When is Michael available next week?',
     lang === 'de' ? 'Welche Erfahrung hat Michael mit KI-Agenten?' : 'What is Michael’s experience with AI agents?',
   ],
-  facts: ['protocolVersion: 0.3', 'transport: JSONRPC', 'streaming: true', 'skills: 4'],
+  facts: ['protocolVersion: 0.3', 'transport: JSONRPC', 'streaming: true', 'skills: 5'],
 };
 
 // NOTE: a skill in ui.sidebar_skills that matches NONE of these group regexes
@@ -253,7 +253,13 @@ const INITIAL_PROJECTS = 6; // featured cards shown before the "show all" expand
           <div class="mt-4 rounded-xl p-4 cv-agent-terminal">
             <p class="text-sm font-medium">{agentProof.status}</p>
             <p class="mt-1 text-xs leading-relaxed" style="color: var(--text-secondary)">{agentProof.endpoint}</p>
-            <div class="mt-4 flex flex-wrap gap-2">
+            {/* These chips describe the LIVE agent, so AgentWidget rewrites them from
+                the agent-card as soon as it loads (see factsFromCard there). What
+                renders here is the fallback for a visitor whose browser cannot reach
+                the agent — and it is the only hand-written copy left, which is exactly
+                why it went stale: it claimed protocolVersion 0.3 and skills 4 while the
+                live card said otherwise. The card is the source of truth. */}
+            <div class="mt-4 flex flex-wrap gap-2" data-agent-facts>
               {agentProof.facts.map(fact => (
                 <span class="cv-agent-fact rounded-full px-2.5 py-1 text-[11px]">{fact}</span>
               ))}


### PR DESCRIPTION
## Why

The chips under *"Mein CV hat einen eigenen KI-Agenten"* are hand-written in `config.cv.toml`. Both values that describe the running agent had drifted:

| chip | claimed | live card |
|---|---|---|
| `protocolVersion` | 0.3 | 0.3 **today only** — pinned there by a CORE bug ([open-bridge#121](https://github.com/bks-lab/open-bridge/pull/121)); wrong the moment that merges |
| `skills` | 4 | **5** |

They describe a live system, so they now come from that system's card. The hand-written pair stays as the fallback for a visitor who can't reach the agent — the only copy left, and no longer the source of truth.

## How

`factsFromCard()` reads **both A2A dialects**: v1.0 keeps `protocolVersion` + binding on `supportedInterfaces[]`, v0.3 keeps them top-level. Reading only one location is precisely the bug that silently cut this agent's own BKS consult off for five days — not repeating it one layer up.

Progressive enhancement:
- the server still renders the config values, so there's no empty state and no layout shift
- `loadAgentCard()` de-dupes + caches → at most **one extra GET** of static JSON, and **zero** when auto-open already fetched it
- any failure (agent down, CORS, stale override) leaves the fallback standing
- chip text via `textContent`, never `innerHTML` — the card is remote data

## Verification

Driven in a real browser against both live cards, with a **sentinel** fallback (`skills: 999`, `protocolVersion: SENTINEL-FB`) so the test could actually discriminate — identical values would have proven nothing:

| proxy target | card dialect | chips rendered |
|---|---|---|
| `mboiman.bks-lab.com` | v0.3 (top-level) | `protocolVersion: 0.3 · JSONRPC · true · 5` |
| `ai.bks-lab.com` | v1.0 (`supportedInterfaces[]`) | `protocolVersion: 1.0 · JSONRPC · true · 2` |

Both replaced the sentinel, and the card request is visible in the network log. The v1.0 case reads the version off the interface, where the top-level field no longer exists — so once #121 lands and the CV agent serves 1.0, this page follows on its own.

`npm run build` passes (9 pages).

## Note

The two modified PDFs in the working tree are **not** part of this branch — they were already dirty and are left untouched.