### PR TITLE
fix(pdf): Gedankenstriche, die der Renderer wieder einsetzte, und ein Link, der nur 405 liefern kann

### DIFF
--- a/scripts/check-output.mjs
+++ b/scripts/check-output.mjs
@@ -16,6 +16,11 @@
  */
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
+// One rule, two artifacts: scripts/html_to_pdf.js runs the same findDashes over
+// the HTML it hands to Puppeteer, because the PDF is never an HTML page in dist/
+// and no guard here would ever see it. Two regexes for one rule stay in sync
+// exactly as long as nobody edits one of them.
+import { findDashes } from './lib/visible-text.js';
 
 const dist = process.argv[2] ?? 'dist';
 const errors = [];
@@ -30,41 +35,15 @@ function htmlFiles(dir) {
   return out;
 }
 
-/** Everything a reader can see: no scripts, no styles, no HTML comments, no tags. */
-function visibleText(html) {
-  return html
-    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<!--[\s\S]*?-->/g, ' ')
-    .replace(/<[^>]+>/g, ' ');
-}
-
-/** Title and meta description are read too, just not inside the page. */
-function metaText(html) {
-  const bits = [];
-  const title = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
-  if (title) bits.push(title[1]);
-  for (const m of html.matchAll(/<meta[^>]+content="([^"]*)"[^>]*>/gi)) bits.push(m[1]);
-  return bits.join('\n');
-}
-
 let pages = 0;
 let images = 0;
 for (const file of htmlFiles(dist)) {
   pages += 1;
   const html = readFileSync(file, 'utf8');
 
-  // ── No em or en dash as punctuation, anywhere a reader can see it ──────────
-  // Deduplicated per page: one title lands in <title>, og:title and twitter:title,
-  // and three identical lines about one dash only make the report harder to read.
-  const seen = new Set();
-  for (const [label, text] of [['text', visibleText(html)], ['meta', metaText(html)]]) {
-    for (const m of text.matchAll(/[^\n]{0,40}[—–][^\n]{0,40}/g)) {
-      const snippet = m[0].trim().replace(/\s+/g, ' ');
-      if (seen.has(snippet)) continue;
-      seen.add(snippet);
-      errors.push(`${file} (${label}): em or en dash in "${snippet}"`);
-    }
+  // ── No em or en dash as punctuation, anywhere a reader can see it ─────────
+  for (const { where, snippet } of findDashes(html)) {
+    errors.push(`${file} (${where}): em or en dash in "${snippet}"`);
   }
 
   // ── An image is either content with an alt, or explicitly hidden ───────────

--- a/scripts/html_to_pdf.js
+++ b/scripts/html_to_pdf.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const toml = require('toml');
 const sharp = require('sharp');
 const { formatTextToParagraphs } = require('./lib/markdown-utils');
+const { findDashes } = require('./lib/visible-text');
 
 // Verification anchors come from config.cv.toml (ui.impact_metrics). There is
 // deliberately NO hardcoded fallback here: the previous one held '40+ Skills' and
@@ -385,7 +386,7 @@ async function generateHTMLFromConfig(langConfig, profileImageData, targetLang) 
       <div class="experience-item">
         <div class="experience-header">
           <div class="experience-title">${exp.position}</div>
-          <div class="experience-dates">${exp.dates.replace(/\s*[-–]\s*/, ' – ')}</div>
+          <div class="experience-dates">${exp.dates}</div>
         </div>
         <div class="experience-company">${exp.company}</div>
         <div class="experience-details">
@@ -402,7 +403,7 @@ async function generateHTMLFromConfig(langConfig, profileImageData, targetLang) 
       <div class="experience-item experience-medium">
         <div class="experience-header">
           <div class="experience-title">${exp.position}</div>
-          <div class="experience-dates">${exp.dates.replace(/\s*[-–]\s*/, ' – ')}</div>
+          <div class="experience-dates">${exp.dates}</div>
         </div>
         <div class="experience-company">${exp.company}</div>
         <div class="experience-details">
@@ -417,7 +418,7 @@ async function generateHTMLFromConfig(langConfig, profileImageData, targetLang) 
       <table class="compact-table">
         ${compactExperiences.map(exp => `
           <tr class="compact-row">
-            <td class="compact-dates">${exp.dates.replace(/\s*[-–]\s*/, ' – ')}</td>
+            <td class="compact-dates">${exp.dates}</td>
             <td class="compact-role"><strong>${exp.position}</strong>, ${exp.company}</td>
             <td class="compact-summary">${extractFirstSentence(exp.details)}</td>
           </tr>
@@ -1128,6 +1129,19 @@ async function generateHTMLFromConfig(langConfig, profileImageData, targetLang) 
 
   // Generate HTML content directly from TOML config
   const htmlContent = await generateHTMLFromConfig(langConfig, profileImageBase64, targetLang);
+
+  // Same rule as scripts/check-output.mjs applies to the site, checked here
+  // because the PDF is a second artifact that no HTML guard ever sees. It is
+  // needed: this renderer used to rewrite every clean date range from the TOML
+  // ("01/2024-04/2025") into a spaced en dash on the way out, ten per PDF, none
+  // of them present in any source file. The two callers share one rule module
+  // rather than one regex each.
+  const dashes = findDashes(htmlContent, { includeMeta: false });
+  if (dashes.length) {
+    console.error(`PDF content check failed for [${targetLang}]:`);
+    for (const d of dashes) console.error(`  - em or en dash in "${d.snippet}"`);
+    throw new Error('em or en dash in PDF content');
+  }
 
   await page.setContent(htmlContent, {
     waitUntil: ['domcontentloaded'],

--- a/scripts/lib/visible-text.js
+++ b/scripts/lib/visible-text.js
@@ -1,0 +1,56 @@
+/**
+ * The reader-visible text of an HTML document, and the dash rule that applies
+ * to it. Shared, not copied: scripts/check-output.mjs walks dist/ with it, and
+ * scripts/html_to_pdf.js runs it over the HTML it is about to hand to
+ * Puppeteer. Two artifacts, two callers, one rule.
+ *
+ * Why the PDF needs its own gate: config.cv.toml carries clean date ranges
+ * ("01/2024-04/2025") and check-i18n.mjs proves it, but the PDF renderer used
+ * to rewrite every one of them into "01/2024 – 04/2025" on the way out. Ten en
+ * dashes per PDF, none of them in any source file, invisible to a guard that
+ * only reads sources or only reads HTML pages.
+ */
+
+/** Strip scripts, styles, comments and tags. What is left is what a reader sees. */
+function visibleText(html) {
+  return String(html)
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ')
+    .replace(/<[^>]+>/g, ' ');
+}
+
+/** Title and meta description are read too, just not inside the page. */
+function metaText(html) {
+  const bits = [];
+  const title = String(html).match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  if (title) bits.push(title[1]);
+  for (const m of String(html).matchAll(/<meta[^>]+content="([^"]*)"[^>]*>/gi)) bits.push(m[1]);
+  return bits.join('\n');
+}
+
+/**
+ * Em and en dashes used as punctuation, deduplicated per document because one
+ * title lands in <title>, og:title and twitter:title and three identical lines
+ * about one dash only make the report harder to read.
+ *
+ * Returns [{ where, snippet }]. Empty means clean.
+ */
+function findDashes(html, { includeMeta = true } = {}) {
+  const seen = new Set();
+  const hits = [];
+  const sources = includeMeta
+    ? [['text', visibleText(html)], ['meta', metaText(html)]]
+    : [['text', visibleText(html)]];
+  for (const [where, text] of sources) {
+    for (const m of text.matchAll(/[^\n]{0,40}[—–][^\n]{0,40}/g)) {
+      const snippet = m[0].trim().replace(/\s+/g, ' ');
+      if (seen.has(snippet)) continue;
+      seen.add(snippet);
+      hits.push({ where, snippet });
+    }
+  }
+  return hits;
+}
+
+module.exports = { visibleText, metaText, findDashes };

--- a/src/components/AgentWidget.astro
+++ b/src/components/AgentWidget.astro
@@ -1658,10 +1658,17 @@ const widgetStrings = {
       if (endpoint) {
         let host = endpoint;
         try { host = new URL(endpoint).host; } catch {}
-        // Only LINK the endpoint if it's a trusted host (same allowlist as the fetch
-        // target). A semi-trusted card must not turn the widget into an open-redirect
-        // to an arbitrary external site; otherwise show the host as plain text.
-        proto.appendChild(metaLine(t.cardEndpoint || 'Endpoint', host, isAllowedAgent(endpoint) ? endpoint : undefined));
+        // NOT a link, on purpose. An A2A endpoint answers POST; a browser click is
+        // a GET and can only come back as "405 Method Not Allowed", which is what
+        // the verification anchor on the CV page did until 2026-08-22. A control
+        // whose only possible outcome is an error should not look clickable. The
+        // clickable proof of this agent is its card, and the reader is looking at
+        // it right now.
+        //
+        // (The former isAllowedAgent() check guarded against a semi-trusted card
+        // turning the widget into an open redirect. Rendering plain text is the
+        // stricter version of the same protection, so the guard is not lost.)
+        proto.appendChild(metaLine(t.cardEndpoint || 'Endpoint', host));
       }
       cardEl.appendChild(proto);
 


### PR DESCRIPTION
Aus der Abnahme nach dem Merge von #67. Alles am **live ausgelieferten**
Artefakt gemessen, nicht am Quelltext, und dabei sind drei Sachen aufgefallen,
die vorher niemand sehen konnte.

## Zehn Gedankenstriche pro PDF, in keiner Quelldatei

`config.cv.toml` trägt seit #64 saubere Zeitspannen (`01/2024-04/2025`), und
`check-i18n.mjs` beweist das bei jedem Lauf. Der PDF-Renderer schrieb sie an drei
Stellen wieder um:

```js
${exp.dates.replace(/\s*[-–]\s*/, ' – ')}
```

Die Bereinigung von 26 Strichen im TOML hat das PDF also nie erreicht. Dieselbe
Form wie alles andere gestern: eine Regel an der Quelle durchgesetzt, eine
Schicht tiefer aufgehoben, und niemand hat dort nachgemessen.

Datum steht jetzt wörtlich, wie auf der Website. Der Bindestrich im Zahlenbereich
ist erlaubt und liest sich in der Tabelle sauber.

## Die Regel deckt jetzt beide Artefakte

`check-output.mjs` liest `dist/**/*.html` und kann ein PDF nie sehen. Statt eines
zweiten Regex-Literals liegt die Prüfung in `scripts/lib/visible-text.js`, und
`html_to_pdf.js` lässt das HTML, das es an Puppeteer übergibt, durch dieselbe
Funktion laufen. Findet sie etwas, bricht der Lauf vor dem Rendern.

Zwei Regexe für eine Regel bleiben genau so lange gleich, bis jemand einen davon
anfasst.

## Der Endpunkt im Agenten-Steckbrief war ein Link

Ein A2A-Endpunkt antwortet auf POST. Ein Klick im Browser ist ein GET und kann
nur `405 Method Not Allowed` zurückgeben. Genau das hat #67 eine Ebene höher am
Beleg-Anker der Lebenslauf-Seite repariert, und im Widget stand es noch: derselbe
Fehler, zweite Stelle.

Jetzt Text zum Kopieren. Der frühere `isAllowedAgent()`-Schutz gegen eine Card,
die das Widget zur offenen Weiterleitung macht, geht nicht verloren, Text statt
Link ist die strengere Fassung derselben Absicherung.

## Gegenprobe

Strich zurück in den Renderer, Lauf bricht mit den zwei richtigen Zeilen;
zurückgenommen, PDF wieder sauber. Danach:

- beide PDFs 0 Striche, DE fünf Seiten, EN vier, Sprachbot in beiden
- `i18n check ok` und `output check ok` über 9 Seiten und 24 Bilder
- im Browser: Endpunkt ohne Link, keine Links mehr auf den blanken Ursprung,
  die deutsche Seite behält ihre 14 anklickbaren Beispielfragen
