### PR TITLE
chore: open-bridge auf v0.20.2 und eine offene nanoid-Lücke

### DIFF
--- a/config.cv.toml
+++ b/config.cv.toml
@@ -267,7 +267,7 @@ Vollständiger Workshop mit Folien, Live-Demos und praktischen Übungen für mod
 **Entwicklung eines LLM-orchestrierten Enterprise Development Ecosystems**: Vollständig integriertes System für Knowledge Management, Project Automation und Development Workflows mit Claude, Gemini und OpenAI GPT.
 
 **Schwerpunkte**
-- **Quelloffene Agenten-Infrastruktur**: open-bridge unter MIT-Lizenz, öffentlich auf github.com/bks-lab/open-bridge (Stand v0.14.0, mit Live-Demo-Seite). Die generische CORE-Schicht (Agenten-Laufzeit, MCP-Gateway, Skill-Baum, Promote-Flow mit Content-Leak-Gate in der CI) entsteht aus der eigenen Instanz und wird scope-getrieben nach oben veröffentlicht
+- **Quelloffene Agenten-Infrastruktur**: open-bridge unter MIT-Lizenz, öffentlich auf github.com/bks-lab/open-bridge (Stand v0.20.2, mit Live-Demo-Seite). Die generische CORE-Schicht (Agenten-Laufzeit, MCP-Gateway, Skill-Baum, Promote-Flow mit Content-Leak-Gate in der CI) entsteht aus der eigenen Instanz und wird scope-getrieben nach oben veröffentlicht
 - **Agenten-Netz nach A2A**: a2a-sdk-Server mit lokalem claude-Backend auf einer aus open-bridge übernommenen Laufzeit. Drei Agenten (Person, Firma, OSS-Projekt) befragen sich gegenseitig ausschließlich lesend, davor ein zustandsloses MCP-nach-A2A-Gateway, damit auch reine MCP-Clients die Agenten erreichen. Agent Cards nach Protokollversion 1.0, JSON-RPC 2.0
 - **Git-Wiki Transformation**: Migration der Confluence-Wissensdatenbank zu strukturiertem Git-basiertem Wiki mit hierarchischer Organisation und Multi-Repository-Architektur (Submodules für Kundenprojekte)
 - **MCP Navigation Server**: Entwicklung eines Model Context Protocol Servers (Python) mit intelligenter Hierarchie-Navigation, automatischer Content-Discovery und SharePoint-Integration
@@ -900,7 +900,7 @@ Complete workshop with slides, live demos, and practical exercises for modern AI
 **Development of LLM-orchestrated Enterprise Development Ecosystem**: Fully integrated system for knowledge management, project automation, and development workflows with Claude, Gemini, and OpenAI GPT.
 
 **Key Responsibilities**
-- **Open-Source Agent Infrastructure**: open-bridge under the MIT licence, public at github.com/bks-lab/open-bridge (v0.14.0, with a live demo site). The generic CORE layer (agent runtime, MCP gateway, skill tree, promote flow with a content-leak gate in CI) grows out of my own instance and is published upward by scope
+- **Open-Source Agent Infrastructure**: open-bridge under the MIT licence, public at github.com/bks-lab/open-bridge (v0.20.2, with a live demo site). The generic CORE layer (agent runtime, MCP gateway, skill tree, promote flow with a content-leak gate in CI) grows out of my own instance and is published upward by scope
 - **A2A Agent Network**: an a2a-sdk server with a local claude backend, running on a runtime adopted from open-bridge. Three agents (person, company, OSS project) consult each other on read-only edges, fronted by a stateless MCP-to-A2A gateway so MCP-only clients can reach them. Agent Cards at protocol version 1.0, JSON-RPC 2.0
 - **Git Wiki Transformation**: Migration of Confluence knowledge base to structured Git-based wiki with hierarchical organization and multi-repository architecture (submodules for customer projects)
 - **MCP Navigation Server**: Development of Model Context Protocol server (Python) with intelligent hierarchy navigation, automatic content discovery, and SharePoint integration
@@ -1308,7 +1308,7 @@ The full presentation is available at [Pitch.com](https://pitch.com/public/bc7ea
 • **Hook-basiertes Permission System**: Smart Guard mit projektspezifischen Sicherheitsregeln (Branch-Schutz, Secret-Erkennung, Deployment-Gates)
 • **Strukturiertes Arbeits-Tracking**: Automatische Dokumentation mit Tages-/Wochen-Archivierung und Cross-Project Kanban Board
 • **Cross-Repo Automation**: Nahtlose Navigation und Operationen über Kunden-, Partner- und interne Repositories
-• **Open-Source-Schicht**: Three-Tier-Architektur. Die generische CORE-Schicht liegt offen als bks-lab/open-bridge (MIT, Stand v0.14.0, mit Live-Demo-Seite) und speist sich aus dieser Saat-Instanz, BKS-Overlay dazwischen.
+• **Open-Source-Schicht**: Three-Tier-Architektur. Die generische CORE-Schicht liegt offen als bks-lab/open-bridge (MIT, Stand v0.20.2, mit Live-Demo-Seite) und speist sich aus dieser Saat-Instanz, BKS-Overlay dazwischen.
 
 **Impact:** Produktivitätssteigerung durch AI-gesteuerte Workflows, von Incident-Response bis Meeting-Protokollierung weitgehend automatisiert"""
         tagline_pdf = '''
@@ -1628,7 +1628,7 @@ Telefonischer Sprachassistent, der freie Termine live aus dem Terminportal liest
 • **Hook-based Permission System**: Smart Guard with project-specific security rules (branch protection, secret detection, deployment gates)
 • **Structured Work Tracking**: Automatic documentation with daily/weekly archiving and cross-project Kanban board
 • **Cross-Repo Automation**: Seamless navigation and operations across customer, partner and internal repositories
-• **Open-source layer**: three-tier architecture. The generic CORE layer is public as bks-lab/open-bridge (MIT, v0.14.0, with a live demo site) and is fed from this seed instance, with a BKS overlay in between.
+• **Open-source layer**: three-tier architecture. The generic CORE layer is public as bks-lab/open-bridge (MIT, v0.20.2, with a live demo site) and is fed from this seed instance, with a BKS overlay in between.
 
 **Impact:** Productivity boost through AI-driven workflows, from incident response to meeting documentation largely automated"""
         tagline_pdf = '''

--- a/package-lock.json
+++ b/package-lock.json
@@ -4151,9 +4151,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/scripts/check-i18n.mjs
+++ b/scripts/check-i18n.mjs
@@ -290,6 +290,7 @@ const RENDERED_FIELDS = [
 // skipped entirely before: the walker only tested `typeof v === 'string'` for
 // OBJECT properties, and an array element has no property name to test.
 const cvRaw = readFileSync(new URL('../config.cv.toml', import.meta.url), 'utf8');
+const i18nRaw = readFileSync(new URL('../src/lib/i18n.ts', import.meta.url), 'utf8');
 const cv = tomlParse(cvRaw);
 for (const branch of ['de', 'en']) {
   const params = cv?.languages?.[branch]?.params;
@@ -338,6 +339,36 @@ for (const branch of ['de', 'en']) {
 // branch only produces two different CVs behind one download button.
 if (rankSets.de !== rankSets.en) {
   errors.push(`config.cv.toml: pdf_rank differs between branches.\n      de: ${rankSets.de}\n      en: ${rankSets.en}`);
+}
+
+/**
+ * One version number, six places.
+ *
+ * The CV names the open-bridge release in six spots: four prose passages in
+ * config.cv.toml and two `running[].proof` anchors in i18n.ts. On 2026-08-22 all
+ * six still said v0.14.0 while the repo was at v0.20.2, six minors along. A
+ * pinned version on a page whose whole argument is "open it and check" ages into
+ * the exact opposite of a proof.
+ *
+ * Nothing here can reach the network, so this cannot know the true version. What
+ * it CAN do is make the six agree, which is the failure mode that actually bit:
+ * a hand-bump that misses a copy. One number to change, and a broken build if a
+ * copy is left behind.
+ */
+const versions = new Map();
+for (const [label, text] of [['config.cv.toml', cvRaw], ['src/lib/i18n.ts', i18nRaw]]) {
+  for (const m of text.matchAll(/\bv\d+\.\d+\.\d+\b/g)) {
+    if (!versions.has(m[0])) versions.set(m[0], []);
+    versions.get(m[0]).push(label);
+  }
+}
+if (versions.size > 1) {
+  const listed = [...versions.entries()]
+    .map(([v, files]) => `${v} (${[...new Set(files)].join(', ')})`)
+    .join(' vs ');
+  errors.push(`open-bridge version disagrees across files: ${listed}. One release, one number.`);
+} else if (versions.size === 0) {
+  errors.push('no open-bridge release version found in config.cv.toml or src/lib/i18n.ts. It is one of the four allowed proof anchors; do not drop it silently.');
 }
 
 /**

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -655,7 +655,7 @@ export const i18n: Record<'de' | 'en', I18nStrings> = {
       {
         title: 'open-bridge, die quelloffene Schicht',
         mechanism: 'Das generische Gerüst hinter dieser Arbeitsweise liegt öffentlich unter MIT: Betriebshandbuch, Fähigkeiten, Regeln, Agenten-Laufzeit. Vor jedem Merge laufen Pflichtprüfungen, darunter ein Scan auf durchgesickerte Inhalte.',
-        proof: 'github.com/bks-lab/open-bridge · MIT · v0.14.0',
+        proof: 'github.com/bks-lab/open-bridge · MIT · v0.20.2',
         proofUrl: 'https://github.com/bks-lab/open-bridge',
         state: 'public',
       },
@@ -1083,7 +1083,7 @@ export const i18n: Record<'de' | 'en', I18nStrings> = {
       {
         title: 'open-bridge, the open-source layer',
         mechanism: 'The generic scaffolding behind this way of working is public under MIT: operating manual, skills, rules, agent runtime. Mandatory checks run before every merge, one of them a scan for leaked content.',
-        proof: 'github.com/bks-lab/open-bridge · MIT · v0.14.0',
+        proof: 'github.com/bks-lab/open-bridge · MIT · v0.20.2',
         proofUrl: 'https://github.com/bks-lab/open-bridge',
         state: 'public',
       },


### PR DESCRIPTION
Der Update-Durchgang nach der Abnahme. Zwei Sachen waren wirklich veraltet, zwei
weitere waren nur meine eigene Fehlmessung.

## Die Versionsangabe war sechs Minors hinten

Die Seite behauptete an sechs Stellen `v0.14.0`. `bks-lab/open-bridge` steht bei
**v0.20.2**, veröffentlicht heute früh um 06:00.

Auf einer Seite, deren ganzes Argument lautet „mach es auf und prüf es nach",
altert eine handgepinnte Version ins genaue Gegenteil eines Belegs. Vier Stellen
in `config.cv.toml` (Prosa in Berufserfahrung und Projekten), zwei in den
`running[].proof`-Ankern von `i18n.ts`, die auf beiden Lebenslauf-Seiten sichtbar
rendern.

**Neue Regel im Wächter.** Er kommt nicht ins Netz und kann die wahre Version
nicht kennen. Was er kann, ist die sechs Stellen zur Übereinstimmung zwingen, und
genau das war der Fehlermodus: ein Hand-Bump, der eine Kopie übersieht. Eine Zahl
zum Ändern, roter Bau, wenn eine liegen bleibt. Fällt die Version ganz weg,
bricht es ebenfalls, weil ein Release einer der vier erlaubten Beleg-Typen ist.

## Eine offene Sicherheitslücke, drei Wochen alt

`nanoid` 3.3.17 → 3.3.18, GHSA-2v37-7h3g-55p8, **high**, veröffentlicht am
29.07.2026. Genau eine Zeile im Lockfile, `package.json` unberührt, danach null
Befunde.

Einordnung ohne Dramatik: die Abhängigkeit ist transitiv und rein baubezogen
(`@tailwindcss/vite` → `vite` → `postcss` → `nanoid`) und erreicht nie den
Browser eines Besuchers. Trotzdem war sie drei Wochen offen.

**Der eigentlich unangenehme Teil:** GitHub meldet für dieses Repo **null offene
Dependabot-Alerts**, obwohl `dependabot_security_updates` aktiv ist, die
Schwachstelle als GHSA gelistet ist und die verwundbare Version im eingecheckten
Lockfile steht. Gefunden hat sie `npm audit` von Hand, nicht die Automatik. Das
ist einen Blick in die Repo-Einstellungen wert, unabhängig von diesem PR.

## Was ich zuerst falsch gemessen habe

`npm outdated` meldete zusätzlich puppeteer 25.5.0 → 25.8.0 und astro 7.2.0 →
7.2.4. Das las nur meine veralteten lokalen `node_modules`, nicht das Repo. Das
Lockfile pinnt puppeteer bereits auf 25.8.0 (aktuell), und astro auf 7.2.2, also
genau einen Patch hinten. Der kommt Montag mit dem wöchentlichen
Dependabot-Bündel, wie es `dependabot.yml` vorsieht. Hier deshalb nicht mit
hineingezogen.

## Nachgemessen

- Gegenprobe A: eine Kopie auf eine andere Version gesetzt → Wächter nennt beide
  Werte samt Dateien
- Gegenprobe B: Version ganz entfernt → Wächter nennt den zweiten Fall
- zurückgenommen → grün, Dateien byte-identisch
- beide PDFs: 0 Striche, DE fünf Seiten, EN vier, `v0.20.2`, Sprachbot drin
- `i18n check ok` und `output check ok` über 9 Seiten und 24 Bilder
- `npm audit`: 0 Schwachstellen

Nebenbei geprüft und in Ordnung: alle drei Terminalzeilen aus Akt 04 stimmen
weiter gegen das heutige Repo (`head -1 LICENSE` → MIT License,
`ls rules/ | grep -E 'guard|safety'` → promote-safety.md + push-guard.md,
`ls agents/ | grep gateway` → `_gateway`), die Live-Demo-Seite antwortet mit 200,
und die Lizenz ist weiterhin MIT.
