### PR TITLE
feat(cv): Vorträge zeigen ihren Inhalt und ihre Belege, Orchestrator-Karte verlinkt

### DIFF
--- a/config.cv.toml
+++ b/config.cv.toml
@@ -1446,6 +1446,7 @@ Guideline-basierter KI-Agent in der Entwicklungsumgebung, der Tests aus Jira-Sto
         [[languages.de.params.projects.list]]
         title = "AI Context Orchestrator: Multi-Repo Development Platform"
         anchor = "ai-context-orchestrator"
+        url = "https://github.com/bks-lab/open-bridge"
         pdf_rank = 6
         tech_stack = ["Python", "YAML", "Claude Code Plugins", "Hooks API", "GitHub Actions", "Elasticsearch", "Azure Functions", "Microsoft Graph API"]
         category = "AI & DevOps"
@@ -1772,6 +1773,7 @@ Guideline-based AI agent in the IDE that generates tests from Jira stories.
         [[languages.en.params.projects.list]]
         title = "AI Context Orchestrator: Multi-Repo Development Platform"
         anchor = "ai-context-orchestrator"
+        url = "https://github.com/bks-lab/open-bridge"
         pdf_rank = 6
         tech_stack = ["Python", "YAML", "Claude Code Plugins", "Hooks API", "GitHub Actions", "Elasticsearch", "Azure Functions", "Microsoft Graph API"]
         category = "AI & DevOps"

--- a/src/components/CVPage.astro
+++ b/src/components/CVPage.astro
@@ -136,6 +136,23 @@ function clipLead(text: string): string {
   return lastStop > 40 ? clipped.slice(0, lastStop + 1) : `${clipped}…`;
 }
 
+/**
+ * The public links buried in a talk's `details`.
+ *
+ * Talks rendered as three lines (title, host, date) and nothing else, so their
+ * `details` reached no reader at all: 5,035 characters in the German branch.
+ * Two of those characters-worth are the only third-party evidence on this whole
+ * page, a public slide deck and the GitHub repo of the bot built in the
+ * workshop, and "pitch.com" produced zero hits in the built HTML.
+ */
+function talkLinks(details: string): { label: string; url: string }[] {
+  const out: { label: string; url: string }[] = [];
+  const rx = /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g;
+  let m: RegExpExecArray | null;
+  while ((m = rx.exec(details || ''))) out.push({ label: m[1], url: m[2] });
+  return out;
+}
+
 function splitDetails(details: string): { open: string; foldTitle: string; fold: string } {
   const focusPattern = new RegExp(`^(${t.truncatePatterns.join('|')})`, 'i');
   const toolPattern = new RegExp(`^(${t.truncateToolPatterns.join('|')})`, 'i');
@@ -597,6 +614,16 @@ const INITIAL_PROJECTS = 6; // featured cards shown before the "show all" expand
                   <h3 class="text-sm font-medium font-sans leading-snug" style="color: var(--accent)">{talk.position}</h3>
                   <p class="text-xs mt-1" style="color: var(--text-secondary)">{talk.company}</p>
                   <span class="cv-date-pill inline-block mt-2 text-[11px] font-medium px-2 py-0.5 rounded-md">{talk.dates}</span>
+                  {splitDetails(talk.details ?? '').open && (
+                    <div class="talk-copy mt-3 text-[13px] leading-[1.7]" set:html={formatToHTML(splitDetails(talk.details ?? '').open)} />
+                  )}
+                  {talkLinks(talk.details ?? '').length > 0 && (
+                    <p class="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-xs">
+                      {talkLinks(talk.details ?? '').map(l => (
+                        <a href={l.url} target="_blank" rel="noopener" class="cv-talk-link">{l.label}</a>
+                      ))}
+                    </p>
+                  )}
                 </div>
               ))}
             </div>
@@ -818,6 +845,17 @@ const INITIAL_PROJECTS = 6; // featured cards shown before the "show all" expand
      shadow and the accent ring outside it were three treatments on one face. */
   .cv-avatar {
     border: 1px solid var(--line);
+  }
+
+  .cv-talk-link {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .talk-copy {
+    color: var(--text-secondary);
+    max-width: 56ch;
   }
 
   .cv-facts {


### PR DESCRIPTION
Dieser Commit hing schon am Branch von #71, als der gemerged wurde, ist aber **nicht mit reingegangen**: GitHub hatte den PR-Kopf nie auf den neueren Stand gezogen, gemerged wurde `0391f5d`. Hier unverändert nachgereicht.

## Vorträge zeigen ihren Inhalt

Die vier Vortragskarten rendern bisher drei Zeilen: Titel, Veranstalter, Datum. Ihre `details` erreichten damit **keinen Leser**, 5.035 Zeichen im deutschen Zweig.

Darin liegen die **einzigen beiden Fremdbelege der ganzen Seite**: ein öffentlicher Foliensatz und das GitHub-Repository des im Workshop gebauten Q&A-Bots. `pitch.com` lieferte null Treffer im gebauten HTML.

Jetzt rendert die Karte den Einleitungsteil und darunter die enthaltenen Links als Belegzeile. Karten wachsen von rund 80 auf 510 bis 921 Zeichen; sie stehen zu zweit nebeneinander, das trägt.

## Orchestrator-Karte verlinkt

Sie beschreibt genau das System, dessen generische Schicht offen unter MIT liegt, und trug trotzdem keinen Link. Von 17 Karten waren zwei verlinkt, jetzt drei.

## Verifiziert

Bau grün, `output check ok: 9 pages, 20 images`. Alle fünf externen Ziele auf Erreichbarkeit geprüft, alle 200:

| Ziel | Status |
|---|---|
| pitch.com Foliensatz | 200 |
| github.com/boiman-solutions/workshop-q-a-scrap-bot | 200 |
| github.com/bks-lab/open-bridge | 200 |
| github.com/bks-lab/experimental-django-sla-dashboard | 200 |
| wecation.de | 200 |
